### PR TITLE
Fix campaign items API endpoint path

### DIFF
--- a/src/realize/tools/campaign_handlers.py
+++ b/src/realize/tools/campaign_handlers.py
@@ -95,7 +95,7 @@ async def get_campaign_items(arguments: dict = None) -> List[types.TextContent]:
             )]
         
         # Make API request to get campaign items - returns raw JSON dict
-        response = await client.get(f"/{account_id}/campaigns/{campaign_id}/campaign_items")
+        response = await client.get(f"/{account_id}/campaigns/{campaign_id}/items/")
         
         return [types.TextContent(
             type="text",
@@ -132,7 +132,7 @@ async def get_campaign_item(arguments: dict = None) -> List[types.TextContent]:
             )]
         
         # Make API request to get campaign item details - returns raw JSON dict
-        response = await client.get(f"/{account_id}/campaigns/{campaign_id}/campaign_items/{item_id}")
+        response = await client.get(f"/{account_id}/campaigns/{campaign_id}/items/{item_id}")
         
         return [types.TextContent(
             type="text",


### PR DESCRIPTION
## Summary
- Fixed `get_campaign_items` endpoint from `/campaign_items` to `/items/`
- Fixed `get_campaign_item` endpoint from `/campaign_items/{item_id}` to `/items/{item_id}`

## Problem
The Backstage API uses `/items/` not `/campaign_items`, causing 404 errors when fetching campaign items.

## Test plan
- [x] Tested locally with campaign - successfully retrieved 90 items

🤖 Generated with [Claude Code](https://claude.com/claude-code)