### PR TITLE
Transform dynamic report settings output into AI-readable metamodel menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,4 +175,8 @@ temp/
 # Distribution / packaging (PyPI deployment)
 build/
 dist/
-*.egg-info/ 
+*.egg-info/
+
+# Local agent/tooling state
+.a5c/
+.agent-mail/

--- a/src/realize/realize_server.py
+++ b/src/realize/realize_server.py
@@ -98,7 +98,16 @@ async def handle_call_tool(
         elif handler_path == "report_handlers.get_campaign_site_day_breakdown_report":
             from realize.tools.report_handlers import get_campaign_site_day_breakdown_report
             return await get_campaign_site_day_breakdown_report(arguments)
-            
+
+        # Dynamic report handlers
+        elif handler_path == "dynamic_report_handlers.get_dynamic_report_settings":
+            from realize.tools.dynamic_report_handlers import get_dynamic_report_settings
+            return await get_dynamic_report_settings(arguments)
+
+        elif handler_path == "dynamic_report_handlers.get_dynamic_report_data":
+            from realize.tools.dynamic_report_handlers import get_dynamic_report_data
+            return await get_dynamic_report_data(arguments)
+
         else:
             raise ValueError(f"Handler not implemented: {handler_path}")
             

--- a/src/realize/tools/dynamic_report_handlers.py
+++ b/src/realize/tools/dynamic_report_handlers.py
@@ -1,0 +1,336 @@
+"""Dynamic report handlers for Realize MCP server."""
+import json
+import logging
+from typing import List
+import httpx
+import mcp.types as types
+from realize.tools.utils import format_large_response_with_csv_truncation, validate_account_id
+from realize.client import client
+
+logger = logging.getLogger(__name__)
+
+
+USAGE_GUIDE = """
+## HOW TO USE THIS DATA WITH get_dynamic_report_data
+
+1. **Pick columns** from the DIMENSIONS and METRICS sections below (copy the exact backtick-wrapped names)
+2. **Choose a date_preset** (REQUIRED): LAST_7_DAYS, LAST_30_DAYS, LAST_3_MONTHS, YESTERDAY, TODAY
+3. **Add filters** (optional): only fields listed in FILTERABLE FIELDS can be filtered
+
+### Example call:
+```json
+{
+  "account_id": "<same account_id>",
+  "columns": [
+    "PERFORMANCE_REPORT.CAMPAIGN.CAMPAIGN_NAME",
+    "PERFORMANCE_REPORT.METRICS.CLICKS",
+    "PERFORMANCE_REPORT.METRICS.SPENT"
+  ],
+  "date_preset": "LAST_7_DAYS"
+}
+```
+
+### Key rules:
+- Column/filter names MUST be exact fully qualified names (e.g. PERFORMANCE_REPORT.METRICS.CLICKS, NOT "clicks")
+- date_preset is REQUIRED - queries without it will fail
+- ACCOUNT_ID and DAY filters are auto-injected - do NOT add them
+- All filter values MUST be strings (even numbers: "100" not 100)
+"""
+
+# Fields auto-injected by the query builder; hide from the AI menu
+_SKIP_FIELDS = {"ACCOUNT_ID", "DAY"}
+
+
+async def get_dynamic_report_settings(arguments: dict = None) -> List[types.TextContent]:
+    """Get available dimensions, metrics, filters and options for dynamic reports (read-only)."""
+    try:
+        account_id = arguments.get("account_id") if arguments else None
+        report_type = arguments.get("report_type", "PERFORMANCE") if arguments else "PERFORMANCE"
+
+        # Validate account_id format
+        is_valid, error_message = validate_account_id(account_id)
+        if not is_valid:
+            return [types.TextContent(
+                type="text",
+                text=error_message
+            )]
+
+        # GET /{account_id}/dynamic-reports/metamodel/{report_type}
+        endpoint = f"/{account_id}/dynamic-reports/metamodel/{report_type}"
+        response = await client.get(endpoint)
+
+        metamodel_menu = _format_metamodel_for_ai(response)
+        return [types.TextContent(
+            type="text",
+            text=f"Dynamic Report Settings - Account: {account_id} | Type: {report_type}\n{USAGE_GUIDE}\n---\n{metamodel_menu}"
+        )]
+
+    except Exception as e:
+        logger.error(f"Failed to get dynamic report settings: {e}")
+        return [types.TextContent(
+            type="text",
+            text=f"❌ **Error:** Failed to get dynamic report settings: {str(e)}"
+        )]
+
+
+def _extract_numeric_account_id(metamodel: dict) -> str:
+    """Extract numeric account ID from metamodel ACCOUNT_ID filter."""
+    report = metamodel.get("report", metamodel)
+    top_nodes = report.get("nodes", {})
+    if isinstance(top_nodes, dict):
+        for group in top_nodes.get("values", []):
+            child_nodes = group.get("nodes")
+            if child_nodes and isinstance(child_nodes, dict):
+                for node in child_nodes.get("values", []):
+                    if node.get("name") == "PERFORMANCE_REPORT.ACCOUNT.ACCOUNT_ID":
+                        filters = node.get("filters")
+                        if filters and isinstance(filters, dict):
+                            for f in filters.get("values", []):
+                                fv = f.get("filter_values", [])
+                                if fv:
+                                    return str(fv[0])
+    return None
+
+
+def _format_metamodel_for_ai(metamodel: dict) -> str:
+    """Transform raw metamodel JSON into a flat, AI-readable markdown menu.
+
+    Walks report.nodes.values -> group -> nodes.values -> individual nodes
+    and produces DIMENSIONS, METRICS, and FILTERABLE FIELDS sections.
+    Skips auto-injected fields (ACCOUNT_ID, DAY).
+    """
+    report = metamodel.get("report", metamodel)
+    top_nodes = report.get("nodes", {})
+    if not isinstance(top_nodes, dict):
+        return "(No metamodel data available)"
+
+    groups = top_nodes.get("values", [])
+    if not groups:
+        return "(No metamodel data available)"
+
+    dimensions = []  # (group_label, name, label, data_type)
+    metrics = []     # (group_label, name, label, data_type)
+    filterable = []  # (name, label, operators, values)
+
+    for group in groups:
+        group_label = group.get("label", group.get("name", ""))
+        child_nodes = group.get("nodes")
+        if not child_nodes or not isinstance(child_nodes, dict):
+            continue
+        for node in child_nodes.get("values", []):
+            name = node.get("name", "")
+            label = node.get("label", "")
+            data_type = node.get("data_type", "")
+            node_type = node.get("type", "")
+
+            # Skip auto-injected fields
+            short_name = name.rsplit(".", 1)[-1] if name else ""
+            if short_name in _SKIP_FIELDS:
+                # Also skip if mandatory
+                filters_section = node.get("filters")
+                if filters_section and isinstance(filters_section, dict):
+                    for f in filters_section.get("values", []):
+                        mc = f.get("mandatory_condition", {})
+                        if isinstance(mc, dict) and mc.get("value") == "true":
+                            break
+                    else:
+                        # Not mandatory, but still in skip list (DAY)
+                        pass
+                continue
+
+            if node_type == "ROW":
+                dimensions.append((group_label, name, label, data_type))
+            elif node_type == "COLUMN":
+                metrics.append((group_label, name, label, data_type))
+
+            # Collect filterable fields
+            filters_section = node.get("filters")
+            if filters_section and isinstance(filters_section, dict):
+                for f in filters_section.get("values", []):
+                    operators = f.get("operators", [])
+                    values = f.get("filter_values", [])
+                    # Skip mandatory filters
+                    mc = f.get("mandatory_condition", {})
+                    if isinstance(mc, dict) and mc.get("value") == "true":
+                        continue
+                    filterable.append((name, label, operators, values))
+
+    lines = []
+
+    # DIMENSIONS section
+    lines.append("## DIMENSIONS (use in `columns` parameter)")
+    current_group = None
+    for group_label, name, label, data_type in dimensions:
+        if group_label != current_group:
+            lines.append(f"### {group_label}")
+            current_group = group_label
+        lines.append(f"- `{name}` -- {label} ({data_type})")
+
+    lines.append("")
+
+    # METRICS section
+    lines.append("## METRICS (use in `columns` parameter)")
+    current_group = None
+    for group_label, name, label, data_type in metrics:
+        if group_label != current_group:
+            lines.append(f"### {group_label}")
+            current_group = group_label
+        lines.append(f"- `{name}` -- {label} ({data_type})")
+
+    # FILTERABLE FIELDS section
+    if filterable:
+        lines.append("")
+        lines.append("## FILTERABLE FIELDS")
+        for name, label, operators, values in filterable:
+            parts = f"- `{name}` ({label})"
+            if operators:
+                parts += f" -- operators: {', '.join(operators)}"
+            if values:
+                parts += f" -- values: [{', '.join(str(v) for v in values)}]"
+            lines.append(parts)
+
+    # Summary
+    lines.append("")
+    lines.append(f"**Total: {len(dimensions)} dimensions, {len(metrics)} metrics, {len(filterable)} filterable fields**")
+
+    return "\n".join(lines)
+
+
+def _build_query(report_type, columns, date_preset, filters, numeric_account_id):
+    """Build the correct nested API query structure.
+
+    The real API uses:
+    - columns.values (not columns.columns)
+    - filters.values (not filters.filters)
+    - filter_operator, filter_values, filter_type (not operator, values)
+    - Fully qualified node names (PERFORMANCE_REPORT.CAMPAIGN.CAMPAIGN_NAME)
+    - Mandatory ACCOUNT_ID and DAY filters
+    """
+    query = {
+        "report_reference": {
+            "report_type": report_type
+        },
+        "columns": {
+            "values": [
+                {"node_reference": {"name": col}} for col in columns
+            ]
+        },
+        "filters": {
+            "values": [
+                # Mandatory date filter
+                {
+                    "node_reference": {"name": "PERFORMANCE_REPORT.TIME_UNITS.DAY"},
+                    "filter_type": "PREDEFINED_FILTER",
+                    "filter_operator": "EQUALS",
+                    "filter_values": [date_preset]
+                },
+                # Mandatory account ID filter
+                {
+                    "node_reference": {"name": "PERFORMANCE_REPORT.ACCOUNT.ACCOUNT_ID"},
+                    "filter_type": "PREDEFINED_FILTER",
+                    "filter_operator": "EQUALS",
+                    "filter_values": [numeric_account_id]
+                }
+            ]
+        }
+    }
+
+    # Add user-provided filters
+    if filters:
+        for f in filters:
+            query["filters"]["values"].append({
+                "node_reference": {"name": f["name"]},
+                "filter_type": "PREDEFINED_FILTER",
+                "filter_operator": f["operator"],
+                "filter_values": f["values"]
+            })
+
+    return query
+
+
+async def get_dynamic_report_data(arguments: dict = None) -> List[types.TextContent]:
+    """Execute a dynamic report query and return results (read-only)."""
+    try:
+        account_id = arguments.get("account_id") if arguments else None
+        columns = arguments.get("columns") if arguments else None
+        date_preset = arguments.get("date_preset") if arguments else None
+        filters = arguments.get("filters") if arguments else None
+        report_type = arguments.get("report_type", "PERFORMANCE") if arguments else "PERFORMANCE"
+
+        # Validate account_id format
+        is_valid, error_message = validate_account_id(account_id)
+        if not is_valid:
+            return [types.TextContent(
+                type="text",
+                text=error_message
+            )]
+
+        if not columns or not isinstance(columns, list) or len(columns) == 0:
+            return [types.TextContent(
+                type="text",
+                text="columns is required - provide a list of fully qualified dimension/metric names from get_dynamic_report_settings (e.g. [\"PERFORMANCE_REPORT.CAMPAIGN.CAMPAIGN_NAME\", \"PERFORMANCE_REPORT.METRICS.CLICKS\"])"
+            )]
+
+        if not date_preset or not isinstance(date_preset, str):
+            return [types.TextContent(
+                type="text",
+                text="date_preset is required - use one of: LAST_7_DAYS, LAST_30_DAYS, LAST_3_MONTHS, YESTERDAY, TODAY"
+            )]
+
+        # Validate filter structure if provided
+        if filters:
+            if not isinstance(filters, list):
+                return [types.TextContent(
+                    type="text",
+                    text="filters must be a list of objects with name, operator, and values"
+                )]
+            for i, f in enumerate(filters):
+                if not isinstance(f, dict) or "name" not in f or "operator" not in f or "values" not in f:
+                    return [types.TextContent(
+                        type="text",
+                        text=f"Filter at index {i} is invalid - each filter must have name, operator, and values (e.g. {{\"name\": \"PERFORMANCE_REPORT.CAMPAIGN.CAMPAIGN_STATUS\", \"operator\": \"IN\", \"values\": [\"RUNNING\"]}})"
+                    )]
+
+        # Fetch metamodel to get numeric account ID for mandatory ACCOUNT_ID filter
+        metamodel = await client.get(f"/{account_id}/dynamic-reports/metamodel/{report_type}")
+        numeric_account_id = _extract_numeric_account_id(metamodel)
+        if not numeric_account_id:
+            return [types.TextContent(
+                type="text",
+                text="❌ Could not extract numeric account ID from metamodel. Please verify the account_id is valid."
+            )]
+
+        # Build the nested API query structure
+        query = _build_query(report_type, columns, date_preset, filters, numeric_account_id)
+
+        logger.info(f"Dynamic report query for account {account_id}: {json.dumps(query)}")
+
+        # POST /{account_id}/dynamic-reports/query
+        endpoint = f"/{account_id}/dynamic-reports/query"
+        response = await client.post(endpoint, data=query)
+
+        return [types.TextContent(
+            type="text",
+            text=f"📊 **Dynamic Report Data** - Account: {account_id}\n\n{format_large_response_with_csv_truncation(response)}"
+        )]
+
+    except httpx.HTTPStatusError as e:
+        # Surface the API error response body so we can see what went wrong
+        error_body = ""
+        try:
+            error_body = e.response.text
+        except Exception:
+            pass
+        logger.error(f"Dynamic report API error: {e} | Response: {error_body}")
+        query_sent = json.dumps(query, indent=2) if 'query' in dir() else "unknown"
+        return [types.TextContent(
+            type="text",
+            text=f"❌ **API Error {e.response.status_code}** for dynamic report query.\n\n**API Response:** {error_body}\n\n**Query sent:**\n```json\n{query_sent}\n```\nCheck that column names match exactly from get_dynamic_report_settings metamodel. Use fully qualified names like PERFORMANCE_REPORT.METRICS.CLICKS."
+        )]
+
+    except Exception as e:
+        logger.error(f"Failed to get dynamic report data: {e}")
+        return [types.TextContent(
+            type="text",
+            text=f"❌ **Error:** Failed to get dynamic report data: {str(e)}"
+        )]

--- a/test_api_live.py
+++ b/test_api_live.py
@@ -1,0 +1,150 @@
+"""Live API test - call the actual handler methods end-to-end."""
+import asyncio
+import json
+import sys
+import pathlib
+sys.path.insert(0, str(pathlib.Path(__file__).parent / "src"))
+
+from realize.tools.dynamic_report_handlers import get_dynamic_report_settings, get_dynamic_report_data
+
+
+async def main():
+    account_id = "pumikademoaccount"
+
+    # Test 1: Settings
+    print("=" * 70)
+    print("TEST 1: get_dynamic_report_settings")
+    print("=" * 70)
+    result = await get_dynamic_report_settings({"account_id": account_id})
+    text = result[0].text
+    has_error = "Error" in text or "❌" in text
+    print(f"Status: {'FAIL' if has_error else 'OK'}")
+    print(f"Length: {len(text)} chars")
+    print(text[:800])
+    print("...\n")
+
+    # Test 2: Basic data query
+    print("=" * 70)
+    print("TEST 2: get_dynamic_report_data — campaign name + clicks + spent (7d)")
+    print("=" * 70)
+    result = await get_dynamic_report_data({
+        "account_id": account_id,
+        "columns": [
+            "PERFORMANCE_REPORT.CAMPAIGN.CAMPAIGN_NAME",
+            "PERFORMANCE_REPORT.METRICS.CLICKS",
+            "PERFORMANCE_REPORT.METRICS.SPENT",
+        ],
+        "date_preset": "LAST_7_DAYS",
+    })
+    text = result[0].text
+    has_error = "Error" in text or "❌" in text
+    print(f"Status: {'FAIL' if has_error else 'OK'}")
+    print(f"Length: {len(text)} chars")
+    print(text)
+    print()
+
+    # Test 3: More columns + filter
+    print("=" * 70)
+    print("TEST 3: get_dynamic_report_data — with status filter + more metrics (30d)")
+    print("=" * 70)
+    result = await get_dynamic_report_data({
+        "account_id": account_id,
+        "columns": [
+            "PERFORMANCE_REPORT.CAMPAIGN.CAMPAIGN_NAME",
+            "PERFORMANCE_REPORT.CAMPAIGN.CAMPAIGN_STATUS",
+            "PERFORMANCE_REPORT.METRICS.VISIBLE_IMPRESSIONS",
+            "PERFORMANCE_REPORT.METRICS.CLICKS",
+            "PERFORMANCE_REPORT.METRICS.SPENT",
+            "PERFORMANCE_REPORT.METRICS.CTR",
+        ],
+        "date_preset": "LAST_30_DAYS",
+        "filters": [
+            {"name": "PERFORMANCE_REPORT.CAMPAIGN.CAMPAIGN_STATUS", "operator": "IN", "values": ["RUNNING"]}
+        ],
+    })
+    text = result[0].text
+    has_error = "Error" in text or "❌" in text
+    print(f"Status: {'FAIL' if has_error else 'OK'}")
+    print(f"Length: {len(text)} chars")
+    print(text)
+    print()
+
+    # Test 4: Day-level breakdown
+    print("=" * 70)
+    print("TEST 4: get_dynamic_report_data — day-level breakdown (7d)")
+    print("=" * 70)
+    result = await get_dynamic_report_data({
+        "account_id": account_id,
+        "columns": [
+            "PERFORMANCE_REPORT.TIME_UNITS.DAY",
+            "PERFORMANCE_REPORT.METRICS.VISIBLE_IMPRESSIONS",
+            "PERFORMANCE_REPORT.METRICS.CLICKS",
+            "PERFORMANCE_REPORT.METRICS.SPENT",
+        ],
+        "date_preset": "LAST_7_DAYS",
+    })
+    text = result[0].text
+    has_error = "Error" in text or "❌" in text
+    print(f"Status: {'FAIL' if has_error else 'OK'}")
+    print(f"Length: {len(text)} chars")
+    print(text)
+    print()
+
+    # Test 5: Country breakdown
+    print("=" * 70)
+    print("TEST 5: get_dynamic_report_data — country breakdown (30d)")
+    print("=" * 70)
+    result = await get_dynamic_report_data({
+        "account_id": account_id,
+        "columns": [
+            "PERFORMANCE_REPORT.TARGETING.COUNTRY.NAME",
+            "PERFORMANCE_REPORT.METRICS.VISIBLE_IMPRESSIONS",
+            "PERFORMANCE_REPORT.METRICS.CLICKS",
+            "PERFORMANCE_REPORT.METRICS.SPENT",
+        ],
+        "date_preset": "LAST_30_DAYS",
+    })
+    text = result[0].text
+    has_error = "Error" in text or "❌" in text
+    print(f"Status: {'FAIL' if has_error else 'OK'}")
+    print(f"Length: {len(text)} chars")
+    print(text)
+    print()
+
+    # Test 6: Validation errors
+    print("=" * 70)
+    print("TEST 6: Validation — missing columns")
+    print("=" * 70)
+    result = await get_dynamic_report_data({
+        "account_id": account_id,
+        "date_preset": "LAST_7_DAYS",
+    })
+    print(f"Status: OK (expected error)")
+    print(result[0].text)
+    print()
+
+    print("=" * 70)
+    print("TEST 7: Validation — missing date_preset")
+    print("=" * 70)
+    result = await get_dynamic_report_data({
+        "account_id": account_id,
+        "columns": ["PERFORMANCE_REPORT.METRICS.CLICKS"],
+    })
+    print(f"Status: OK (expected error)")
+    print(result[0].text)
+    print()
+
+    print("=" * 70)
+    print("TEST 8: Validation — numeric account_id")
+    print("=" * 70)
+    result = await get_dynamic_report_data({
+        "account_id": "12345",
+        "columns": ["PERFORMANCE_REPORT.METRICS.CLICKS"],
+        "date_preset": "LAST_7_DAYS",
+    })
+    print(f"Status: OK (expected error)")
+    print(result[0].text)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_dynamic_reports.py
+++ b/tests/test_dynamic_reports.py
@@ -1,0 +1,621 @@
+"""Tests for dynamic report handlers."""
+import pytest
+import sys
+import pathlib
+sys.path.append(str(pathlib.Path(__file__).parent.parent / "src"))
+from unittest.mock import patch, AsyncMock
+import httpx
+from realize.tools.dynamic_report_handlers import (
+    get_dynamic_report_settings, get_dynamic_report_data,
+    _build_query, _extract_numeric_account_id, _format_metamodel_for_ai,
+)
+from realize.realize_server import handle_call_tool
+from realize.tools.registry import get_all_tools
+
+
+MOCK_METAMODEL = {
+    "report": {
+        "id": 101,
+        "name": "PERFORMANCE_REPORT",
+        "version": "1",
+        "nodes": {
+            "values": [
+                {
+                    "name": "PERFORMANCE_REPORT.ACCOUNT",
+                    "type": "GROUP",
+                    "label": "Account",
+                    "nodes": {
+                        "values": [
+                            {
+                                "name": "PERFORMANCE_REPORT.ACCOUNT.ACCOUNT_ID",
+                                "type": "ROW",
+                                "label": "Account ID",
+                                "data_type": "NUMERIC",
+                                "filters": {
+                                    "values": [{
+                                        "type": "PREDEFINED_FILTER",
+                                        "operators": ["EQUALS"],
+                                        "filter_values": ["1065940"],
+                                        "mandatory_condition": {"value": "true"}
+                                    }]
+                                },
+                                "nodes": None
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "PERFORMANCE_REPORT.CAMPAIGN",
+                    "type": "GROUP",
+                    "label": "Campaign",
+                    "nodes": {
+                        "values": [
+                            {
+                                "name": "PERFORMANCE_REPORT.CAMPAIGN.CAMPAIGN_NAME",
+                                "type": "ROW",
+                                "label": "Campaign Name",
+                                "data_type": "STRING",
+                                "nodes": None
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "PERFORMANCE_REPORT.METRICS",
+                    "type": "GROUP",
+                    "label": "Metrics",
+                    "nodes": {
+                        "values": [
+                            {
+                                "name": "PERFORMANCE_REPORT.METRICS.CLICKS",
+                                "type": "COLUMN",
+                                "label": "Clicks",
+                                "data_type": "NUMERIC",
+                                "nodes": None
+                            },
+                            {
+                                "name": "PERFORMANCE_REPORT.METRICS.SPENT",
+                                "type": "COLUMN",
+                                "label": "Spent",
+                                "data_type": "MONEY",
+                                "nodes": None
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    }
+}
+
+
+class TestDynamicReportSettings:
+    """Test get_dynamic_report_settings handler."""
+
+    @pytest.mark.asyncio
+    @patch('realize.tools.dynamic_report_handlers.client.get', new_callable=AsyncMock)
+    async def test_settings_success(self, mock_get):
+        """Test successful settings retrieval with formatted metamodel menu."""
+        mock_get.return_value = MOCK_METAMODEL
+
+        result = await get_dynamic_report_settings({"account_id": "test_account"})
+        assert len(result) == 1
+        text = result[0].text
+        assert "Dynamic Report Settings" in text
+        assert "test_account" in text
+        assert "PERFORMANCE" in text
+        # Verify usage guide is included
+        assert "HOW TO USE THIS DATA" in text
+        assert "get_dynamic_report_data" in text
+        assert "LAST_7_DAYS" in text
+        # Verify formatted metamodel sections are present
+        assert "DIMENSIONS" in text
+        assert "METRICS" in text
+        assert "PERFORMANCE_REPORT.CAMPAIGN.CAMPAIGN_NAME" in text
+        assert "PERFORMANCE_REPORT.METRICS.CLICKS" in text
+        # ACCOUNT_ID metamodel node should be excluded (auto-injected)
+        assert "PERFORMANCE_REPORT.ACCOUNT.ACCOUNT_ID" not in text
+        mock_get.assert_called_once_with(f"/test_account/dynamic-reports/metamodel/PERFORMANCE")
+
+    @pytest.mark.asyncio
+    @patch('realize.tools.dynamic_report_handlers.client.get', new_callable=AsyncMock)
+    async def test_settings_custom_report_type(self, mock_get):
+        """Test settings with custom report type."""
+        mock_get.return_value = MOCK_METAMODEL
+
+        result = await get_dynamic_report_settings({
+            "account_id": "test_account",
+            "report_type": "CUSTOM_TYPE"
+        })
+        assert len(result) == 1
+        assert "CUSTOM_TYPE" in result[0].text
+        mock_get.assert_called_once_with(f"/test_account/dynamic-reports/metamodel/CUSTOM_TYPE")
+
+    @pytest.mark.asyncio
+    async def test_settings_missing_account_id(self):
+        """Test settings with missing account_id."""
+        result = await get_dynamic_report_settings({})
+        assert len(result) == 1
+        assert "account_id is required" in result[0].text
+
+    @pytest.mark.asyncio
+    async def test_settings_numeric_account_id(self):
+        """Test settings with numeric account_id triggers validation error."""
+        result = await get_dynamic_report_settings({"account_id": "12345"})
+        assert len(result) == 1
+        assert "numeric account ID" in result[0].text
+        assert "search_accounts" in result[0].text
+
+    @pytest.mark.asyncio
+    @patch('realize.tools.dynamic_report_handlers.client.get', new_callable=AsyncMock)
+    async def test_settings_api_error(self, mock_get):
+        """Test settings with API error."""
+        mock_get.side_effect = Exception("API connection failed")
+
+        result = await get_dynamic_report_settings({"account_id": "test_account"})
+        assert len(result) == 1
+        assert "Error" in result[0].text
+        assert "API connection failed" in result[0].text
+
+
+class TestExtractNumericAccountId:
+    """Test the _extract_numeric_account_id helper."""
+
+    def test_extracts_from_valid_metamodel(self):
+        """Test extraction from a valid metamodel structure."""
+        result = _extract_numeric_account_id(MOCK_METAMODEL)
+        assert result == "1065940"
+
+    def test_returns_none_for_empty_metamodel(self):
+        """Test returns None for empty metamodel."""
+        result = _extract_numeric_account_id({})
+        assert result is None
+
+    def test_returns_none_for_missing_account_node(self):
+        """Test returns None when ACCOUNT_ID node is missing."""
+        metamodel = {"report": {"nodes": {"values": []}}}
+        result = _extract_numeric_account_id(metamodel)
+        assert result is None
+
+
+class TestBuildQuery:
+    """Test the _build_query helper that constructs the nested API structure."""
+
+    def test_build_query_basic(self):
+        """Test basic query with columns and date preset."""
+        query = _build_query(
+            "PERFORMANCE",
+            ["PERFORMANCE_REPORT.CAMPAIGN.CAMPAIGN_NAME", "PERFORMANCE_REPORT.METRICS.CLICKS"],
+            "LAST_7_DAYS",
+            None,
+            "1065940"
+        )
+        assert query["report_reference"] == {"report_type": "PERFORMANCE"}
+        assert len(query["columns"]["values"]) == 2
+        assert query["columns"]["values"][0] == {"node_reference": {"name": "PERFORMANCE_REPORT.CAMPAIGN.CAMPAIGN_NAME"}}
+        assert query["columns"]["values"][1] == {"node_reference": {"name": "PERFORMANCE_REPORT.METRICS.CLICKS"}}
+        # Should have 2 mandatory filters (DAY + ACCOUNT_ID)
+        assert len(query["filters"]["values"]) == 2
+        day_filter = query["filters"]["values"][0]
+        assert day_filter["node_reference"] == {"name": "PERFORMANCE_REPORT.TIME_UNITS.DAY"}
+        assert day_filter["filter_type"] == "PREDEFINED_FILTER"
+        assert day_filter["filter_operator"] == "EQUALS"
+        assert day_filter["filter_values"] == ["LAST_7_DAYS"]
+        account_filter = query["filters"]["values"][1]
+        assert account_filter["node_reference"] == {"name": "PERFORMANCE_REPORT.ACCOUNT.ACCOUNT_ID"}
+        assert account_filter["filter_values"] == ["1065940"]
+
+    def test_build_query_with_extra_filters(self):
+        """Test query with additional user-provided filters."""
+        filters = [
+            {"name": "PERFORMANCE_REPORT.CAMPAIGN.CAMPAIGN_STATUS", "operator": "IN", "values": ["RUNNING"]},
+            {"name": "PERFORMANCE_REPORT.METRICS.SPENT", "operator": "GREATER_THAN", "values": ["100"]}
+        ]
+        query = _build_query(
+            "PERFORMANCE",
+            ["PERFORMANCE_REPORT.CAMPAIGN.CAMPAIGN_NAME"],
+            "LAST_30_DAYS",
+            filters,
+            "1065940"
+        )
+        # 2 mandatory + 2 user filters = 4
+        assert len(query["filters"]["values"]) == 4
+        status_filter = query["filters"]["values"][2]
+        assert status_filter["node_reference"] == {"name": "PERFORMANCE_REPORT.CAMPAIGN.CAMPAIGN_STATUS"}
+        assert status_filter["filter_operator"] == "IN"
+        assert status_filter["filter_values"] == ["RUNNING"]
+        assert status_filter["filter_type"] == "PREDEFINED_FILTER"
+
+    def test_build_query_no_extra_filters(self):
+        """Test that query always has mandatory filters even with no user filters."""
+        query = _build_query("PERFORMANCE", ["PERFORMANCE_REPORT.METRICS.CLICKS"], "TODAY", None, "999")
+        assert len(query["filters"]["values"]) == 2
+        query2 = _build_query("PERFORMANCE", ["PERFORMANCE_REPORT.METRICS.CLICKS"], "TODAY", [], "999")
+        assert len(query2["filters"]["values"]) == 2
+
+    def test_build_query_uses_values_not_columns(self):
+        """Test that the query uses 'values' key (not 'columns') inside columns object."""
+        query = _build_query("PERFORMANCE", ["PERFORMANCE_REPORT.METRICS.CLICKS"], "LAST_7_DAYS", None, "999")
+        assert "values" in query["columns"]
+        assert "columns" not in query["columns"]
+        assert "values" in query["filters"]
+        assert "filters" not in query["filters"]
+
+
+class TestDynamicReportData:
+    """Test get_dynamic_report_data handler."""
+
+    @pytest.mark.asyncio
+    @patch('realize.tools.dynamic_report_handlers.client.post', new_callable=AsyncMock)
+    @patch('realize.tools.dynamic_report_handlers.client.get', new_callable=AsyncMock)
+    async def test_data_success(self, mock_get, mock_post):
+        """Test successful data query."""
+        mock_get.return_value = MOCK_METAMODEL
+        mock_post.return_value = {
+            "results": [
+                {"data_columns": [
+                    {"id": "campaign_name", "value": "Test Campaign"},
+                    {"id": "clicks", "value": "1,000"},
+                    {"id": "spent", "value": "$50.00"}
+                ]}
+            ],
+            "metadata": {"total": 1}
+        }
+
+        result = await get_dynamic_report_data({
+            "account_id": "test_account",
+            "columns": [
+                "PERFORMANCE_REPORT.CAMPAIGN.CAMPAIGN_NAME",
+                "PERFORMANCE_REPORT.METRICS.CLICKS",
+                "PERFORMANCE_REPORT.METRICS.SPENT",
+            ],
+            "date_preset": "LAST_7_DAYS"
+        })
+        assert len(result) == 1
+        assert "Dynamic Report Data" in result[0].text
+        assert "Test Campaign" in result[0].text
+
+        # Verify the correct nested structure was built
+        call_args = mock_post.call_args
+        assert call_args[0][0] == "/test_account/dynamic-reports/query"
+        sent_query = call_args[1]["data"]
+        assert sent_query["report_reference"] == {"report_type": "PERFORMANCE"}
+        assert len(sent_query["columns"]["values"]) == 3
+        assert sent_query["columns"]["values"][0] == {"node_reference": {"name": "PERFORMANCE_REPORT.CAMPAIGN.CAMPAIGN_NAME"}}
+        # Verify mandatory filters
+        filter_names = [f["node_reference"]["name"] for f in sent_query["filters"]["values"]]
+        assert "PERFORMANCE_REPORT.TIME_UNITS.DAY" in filter_names
+        assert "PERFORMANCE_REPORT.ACCOUNT.ACCOUNT_ID" in filter_names
+
+    @pytest.mark.asyncio
+    @patch('realize.tools.dynamic_report_handlers.client.post', new_callable=AsyncMock)
+    @patch('realize.tools.dynamic_report_handlers.client.get', new_callable=AsyncMock)
+    async def test_data_with_extra_filters(self, mock_get, mock_post):
+        """Test data query with additional user filters."""
+        mock_get.return_value = MOCK_METAMODEL
+        mock_post.return_value = {"results": [{"data_columns": [{"id": "clicks", "value": "50"}]}], "metadata": {"total": 1}}
+
+        result = await get_dynamic_report_data({
+            "account_id": "test_account",
+            "columns": ["PERFORMANCE_REPORT.METRICS.CLICKS"],
+            "date_preset": "LAST_7_DAYS",
+            "filters": [
+                {"name": "PERFORMANCE_REPORT.CAMPAIGN.CAMPAIGN_STATUS", "operator": "IN", "values": ["RUNNING"]}
+            ]
+        })
+        assert len(result) == 1
+        assert "Dynamic Report Data" in result[0].text
+
+        sent_query = mock_post.call_args[1]["data"]
+        assert len(sent_query["filters"]["values"]) == 3  # DAY + ACCOUNT_ID + user filter
+        status_filter = sent_query["filters"]["values"][2]
+        assert status_filter["node_reference"] == {"name": "PERFORMANCE_REPORT.CAMPAIGN.CAMPAIGN_STATUS"}
+        assert status_filter["filter_operator"] == "IN"
+
+    @pytest.mark.asyncio
+    async def test_data_missing_account_id(self):
+        """Test data query with missing account_id."""
+        result = await get_dynamic_report_data({"columns": ["PERFORMANCE_REPORT.METRICS.CLICKS"], "date_preset": "LAST_7_DAYS"})
+        assert len(result) == 1
+        assert "account_id is required" in result[0].text
+
+    @pytest.mark.asyncio
+    async def test_data_missing_columns(self):
+        """Test data query with missing columns."""
+        result = await get_dynamic_report_data({"account_id": "test_account", "date_preset": "LAST_7_DAYS"})
+        assert len(result) == 1
+        assert "columns is required" in result[0].text
+
+    @pytest.mark.asyncio
+    async def test_data_empty_columns(self):
+        """Test data query with empty columns list."""
+        result = await get_dynamic_report_data({"account_id": "test_account", "columns": [], "date_preset": "LAST_7_DAYS"})
+        assert len(result) == 1
+        assert "columns is required" in result[0].text
+
+    @pytest.mark.asyncio
+    async def test_data_missing_date_preset(self):
+        """Test data query with missing date_preset."""
+        result = await get_dynamic_report_data({
+            "account_id": "test_account",
+            "columns": ["PERFORMANCE_REPORT.METRICS.CLICKS"]
+        })
+        assert len(result) == 1
+        assert "date_preset is required" in result[0].text
+
+    @pytest.mark.asyncio
+    async def test_data_invalid_filter_structure(self):
+        """Test data query with invalid filter (missing required keys)."""
+        result = await get_dynamic_report_data({
+            "account_id": "test_account",
+            "columns": ["PERFORMANCE_REPORT.METRICS.CLICKS"],
+            "date_preset": "LAST_7_DAYS",
+            "filters": [{"name": "PERFORMANCE_REPORT.CAMPAIGN.CAMPAIGN_STATUS"}]  # missing operator and values
+        })
+        assert len(result) == 1
+        assert "invalid" in result[0].text.lower()
+
+    @pytest.mark.asyncio
+    async def test_data_numeric_account_id(self):
+        """Test data query with numeric account_id triggers validation error."""
+        result = await get_dynamic_report_data({
+            "account_id": "12345",
+            "columns": ["PERFORMANCE_REPORT.METRICS.CLICKS"],
+            "date_preset": "LAST_7_DAYS"
+        })
+        assert len(result) == 1
+        assert "numeric account ID" in result[0].text
+
+    @pytest.mark.asyncio
+    @patch('realize.tools.dynamic_report_handlers.client.post', new_callable=AsyncMock)
+    @patch('realize.tools.dynamic_report_handlers.client.get', new_callable=AsyncMock)
+    async def test_data_api_error(self, mock_get, mock_post):
+        """Test data query with generic error."""
+        mock_get.return_value = MOCK_METAMODEL
+        mock_post.side_effect = Exception("Server error")
+
+        result = await get_dynamic_report_data({
+            "account_id": "test_account",
+            "columns": ["PERFORMANCE_REPORT.METRICS.CLICKS"],
+            "date_preset": "LAST_7_DAYS"
+        })
+        assert len(result) == 1
+        assert "Error" in result[0].text
+        assert "Server error" in result[0].text
+
+    @pytest.mark.asyncio
+    @patch('realize.tools.dynamic_report_handlers.client.post', new_callable=AsyncMock)
+    @patch('realize.tools.dynamic_report_handlers.client.get', new_callable=AsyncMock)
+    async def test_data_http_400_shows_response_body(self, mock_get, mock_post):
+        """Test that HTTP 400 errors surface the API response body and query sent."""
+        mock_get.return_value = MOCK_METAMODEL
+        mock_response = httpx.Response(
+            status_code=400,
+            request=httpx.Request("POST", "https://example.com/query"),
+            text='{"error": "Invalid column: fake_column"}'
+        )
+        mock_post.side_effect = httpx.HTTPStatusError(
+            "Bad Request", request=mock_response.request, response=mock_response
+        )
+
+        result = await get_dynamic_report_data({
+            "account_id": "test_account",
+            "columns": ["fake_column"],
+            "date_preset": "LAST_7_DAYS"
+        })
+        assert len(result) == 1
+        assert "API Error 400" in result[0].text
+        assert "Invalid column" in result[0].text
+        assert "Query sent" in result[0].text
+        assert "fake_column" in result[0].text
+
+    @pytest.mark.asyncio
+    @patch('realize.tools.dynamic_report_handlers.client.get', new_callable=AsyncMock)
+    async def test_data_metamodel_missing_account_id(self, mock_get):
+        """Test handling when metamodel doesn't contain numeric account ID."""
+        mock_get.return_value = {"report": {"nodes": {"values": []}}}
+
+        result = await get_dynamic_report_data({
+            "account_id": "test_account",
+            "columns": ["PERFORMANCE_REPORT.METRICS.CLICKS"],
+            "date_preset": "LAST_7_DAYS"
+        })
+        assert len(result) == 1
+        assert "numeric account ID" in result[0].text
+
+
+class TestDynamicReportIntegration:
+    """Test dynamic report tools via handle_call_tool dispatch."""
+
+    @pytest.mark.asyncio
+    @patch('realize.tools.dynamic_report_handlers.client.get', new_callable=AsyncMock)
+    async def test_settings_via_dispatch(self, mock_get):
+        """Test get_dynamic_report_settings via handle_call_tool."""
+        mock_get.return_value = MOCK_METAMODEL
+
+        result = await handle_call_tool("get_dynamic_report_settings", {
+            "account_id": "test_account"
+        })
+        assert len(result) == 1
+        assert "Dynamic Report Settings" in result[0].text
+
+    @pytest.mark.asyncio
+    @patch('realize.tools.dynamic_report_handlers.client.post', new_callable=AsyncMock)
+    @patch('realize.tools.dynamic_report_handlers.client.get', new_callable=AsyncMock)
+    async def test_data_via_dispatch(self, mock_get, mock_post):
+        """Test get_dynamic_report_data via handle_call_tool."""
+        mock_get.return_value = MOCK_METAMODEL
+        mock_post.return_value = {
+            "results": [{"data_columns": [{"id": "clicks", "value": "500"}]}],
+            "metadata": {"total": 1}
+        }
+
+        result = await handle_call_tool("get_dynamic_report_data", {
+            "account_id": "test_account",
+            "columns": ["PERFORMANCE_REPORT.CAMPAIGN.CAMPAIGN_NAME", "PERFORMANCE_REPORT.METRICS.CLICKS"],
+            "date_preset": "LAST_7_DAYS"
+        })
+        assert len(result) == 1
+        assert "Dynamic Report Data" in result[0].text
+
+    @pytest.mark.asyncio
+    async def test_settings_validation_via_dispatch(self):
+        """Test validation errors via dispatch."""
+        result = await handle_call_tool("get_dynamic_report_settings", {})
+        assert len(result) == 1
+        assert "account_id is required" in result[0].text
+
+    @pytest.mark.asyncio
+    async def test_data_validation_via_dispatch(self):
+        """Test data validation errors via dispatch."""
+        result = await handle_call_tool("get_dynamic_report_data", {
+            "account_id": "test_account"
+        })
+        assert len(result) == 1
+        assert "columns is required" in result[0].text
+
+
+class TestDynamicReportRegistration:
+    """Verify both tools are registered with correct schemas."""
+
+    def test_tools_registered(self):
+        """Test both dynamic report tools are in registry."""
+        tools = get_all_tools()
+        assert "get_dynamic_report_settings" in tools
+        assert "get_dynamic_report_data" in tools
+
+    def test_total_tool_count(self):
+        """Test total tool count is 13 (11 existing + 2 new)."""
+        tools = get_all_tools()
+        assert len(tools) == 13
+
+    def test_settings_schema(self):
+        """Test settings tool schema structure."""
+        tools = get_all_tools()
+        settings = tools["get_dynamic_report_settings"]
+
+        assert settings["category"] == "dynamic_reports"
+        assert "read-only" in settings["description"].lower()
+        assert settings["schema"]["required"] == ["account_id"]
+        assert "account_id" in settings["schema"]["properties"]
+        assert "report_type" in settings["schema"]["properties"]
+
+    def test_data_schema(self):
+        """Test data tool schema structure."""
+        tools = get_all_tools()
+        data = tools["get_dynamic_report_data"]
+
+        assert data["category"] == "dynamic_reports"
+        assert "read-only" in data["description"].lower()
+        assert "account_id" in data["schema"]["required"]
+        assert "columns" in data["schema"]["required"]
+        assert "date_preset" in data["schema"]["required"]
+        assert "account_id" in data["schema"]["properties"]
+        assert "columns" in data["schema"]["properties"]
+        assert "date_preset" in data["schema"]["properties"]
+
+    def test_dynamic_reports_category_exists(self):
+        """Test dynamic_reports category has exactly 2 tools."""
+        from realize.tools.registry import get_tools_by_category, get_tool_categories
+        categories = get_tool_categories()
+        assert "dynamic_reports" in categories
+
+        dr_tools = get_tools_by_category("dynamic_reports")
+        assert len(dr_tools) == 2
+
+    def test_total_categories(self):
+        """Test total category count is 6."""
+        from realize.tools.registry import get_tool_categories
+        categories = get_tool_categories()
+        assert len(categories) == 6
+
+
+class TestFormatMetamodelForAI:
+    """Test the _format_metamodel_for_ai helper."""
+
+    def test_basic_formatting(self):
+        """Test that output has DIMENSIONS, METRICS sections with correct field names."""
+        result = _format_metamodel_for_ai(MOCK_METAMODEL)
+        assert "## DIMENSIONS" in result
+        assert "## METRICS" in result
+        assert "PERFORMANCE_REPORT.CAMPAIGN.CAMPAIGN_NAME" in result
+        assert "PERFORMANCE_REPORT.METRICS.CLICKS" in result
+        assert "PERFORMANCE_REPORT.METRICS.SPENT" in result
+
+    def test_account_id_excluded(self):
+        """Test that mandatory ACCOUNT_ID field is hidden from the menu."""
+        result = _format_metamodel_for_ai(MOCK_METAMODEL)
+        assert "ACCOUNT_ID" not in result
+
+    def test_group_labels_present(self):
+        """Test that GROUP labels appear as section headers."""
+        result = _format_metamodel_for_ai(MOCK_METAMODEL)
+        assert "### Campaign" in result
+        assert "### Metrics" in result
+
+    def test_empty_metamodel(self):
+        """Test graceful handling of empty metamodel."""
+        result = _format_metamodel_for_ai({})
+        assert "No metamodel data available" in result
+
+    def test_no_nodes(self):
+        """Test graceful handling of metamodel with empty nodes."""
+        result = _format_metamodel_for_ai({"report": {"nodes": {"values": []}}})
+        assert "No metamodel data available" in result
+
+    def test_filterable_fields_section(self):
+        """Test that filterable fields with operators and values are shown."""
+        metamodel_with_filters = {
+            "report": {
+                "nodes": {
+                    "values": [
+                        {
+                            "name": "REPORT.CAMPAIGN",
+                            "type": "GROUP",
+                            "label": "Campaign",
+                            "nodes": {
+                                "values": [
+                                    {
+                                        "name": "REPORT.CAMPAIGN.STATUS",
+                                        "type": "ROW",
+                                        "label": "Campaign Status",
+                                        "data_type": "STRING",
+                                        "filters": {
+                                            "values": [{
+                                                "operators": ["IN", "EQUALS"],
+                                                "filter_values": ["RUNNING", "PAUSED", "STOPPED"]
+                                            }]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+        result = _format_metamodel_for_ai(metamodel_with_filters)
+        assert "## FILTERABLE FIELDS" in result
+        assert "REPORT.CAMPAIGN.STATUS" in result
+        assert "IN" in result
+        assert "EQUALS" in result
+        assert "RUNNING" in result
+
+    def test_summary_counts(self):
+        """Test that summary line shows correct dimension and metric counts."""
+        result = _format_metamodel_for_ai(MOCK_METAMODEL)
+        # MOCK_METAMODEL has 1 dimension (CAMPAIGN_NAME) and 2 metrics (CLICKS, SPENT)
+        # ACCOUNT_ID is skipped
+        assert "1 dimensions" in result
+        assert "2 metrics" in result
+
+    def test_backtick_wrapped_names(self):
+        """Test that field names are wrapped in backticks for copy-paste."""
+        result = _format_metamodel_for_ai(MOCK_METAMODEL)
+        assert "`PERFORMANCE_REPORT.CAMPAIGN.CAMPAIGN_NAME`" in result
+        assert "`PERFORMANCE_REPORT.METRICS.CLICKS`" in result
+        assert "`PERFORMANCE_REPORT.METRICS.SPENT`" in result
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_tool_registration.py
+++ b/tests/test_tool_registration.py
@@ -75,7 +75,8 @@ class TestToolRegistryEdgeCases:
             'auth_handlers.',
             'account_handlers.',
             'campaign_handlers.',
-            'report_handlers.'
+            'report_handlers.',
+            'dynamic_report_handlers.'
         ]
         
         for tool_name, tool_config in tools.items():
@@ -95,7 +96,7 @@ class TestToolRegistryEdgeCases:
         categories = get_tool_categories()
         
         # Should have all expected categories
-        expected_categories = ['authentication', 'accounts', 'campaigns', 'campaign_items', 'reports']
+        expected_categories = ['authentication', 'accounts', 'campaigns', 'campaign_items', 'reports', 'dynamic_reports']
         
         for expected in expected_categories:
             assert expected in categories, f"Expected category {expected} not found"
@@ -165,6 +166,9 @@ class TestToolHandlerImports:
                 elif handler_path.startswith('report_handlers.'):
                     module_name = 'realize.tools.report_handlers'
                     function_name = handler_path.split('.', 1)[1]
+                elif handler_path.startswith('dynamic_report_handlers.'):
+                    module_name = 'realize.tools.dynamic_report_handlers'
+                    function_name = handler_path.split('.', 1)[1]
                 else:
                     pytest.fail(f"Unknown handler pattern for tool {tool_name}: {handler_path}")
                 
@@ -186,9 +190,10 @@ class TestToolHandlerImports:
         """Test that all handler modules exist and can be imported."""
         expected_modules = [
             'realize.tools.auth_handlers',
-            'realize.tools.account_handlers', 
+            'realize.tools.account_handlers',
             'realize.tools.campaign_handlers',
-            'realize.tools.report_handlers'
+            'realize.tools.report_handlers',
+            'realize.tools.dynamic_report_handlers'
         ]
         
         for module_name in expected_modules:


### PR DESCRIPTION
Replace the raw metamodel JSON dump (which truncated to "[Complex data - dict]") with a structured markdown menu showing all 47 dimensions, 12 metrics, and 22 filterable fields. AI agents can now scan, pick items, and directly construct get_dynamic_report_data parameters without relying on a hardcoded list of ~18 common columns.