### PR TITLE
Fix test suite collection errors and broken env-var test

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,2 +1,0 @@
-"""Realize MCP Server - Main package."""
-__version__ = "1.0.0" 

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -72,7 +72,6 @@ class TestEnvironmentVariables:
     
     def test_missing_env_vars_handled_gracefully(self):
         """Test that missing environment variables raise validation error for stdio transport."""
-        # Remove all realize-related env vars temporarily
         original_env = {}
         realize_vars = [key for key in os.environ.keys() if key.startswith('REALIZE_')]
 
@@ -81,24 +80,18 @@ class TestEnvironmentVariables:
             del os.environ[key]
 
         try:
-            # Should raise validation error without credentials for stdio transport
-            import importlib
-            import realize.config
+            from realize.config import Config
             from pydantic_core import ValidationError
 
+            # _env_file=None disables .env loading so the project's real .env can't satisfy validation
             with pytest.raises(ValidationError) as exc_info:
-                importlib.reload(realize.config)
+                Config(_env_file=None)
 
-            # Error should mention missing credentials
             assert "REALIZE_CLIENT_ID" in str(exc_info.value) or "REALIZE_CLIENT_SECRET" in str(exc_info.value)
 
         finally:
-            # Restore environment
             for key, value in original_env.items():
                 os.environ[key] = value
-
-            # Reload config
-            importlib.reload(realize.config)
     
     def test_boolean_env_vars_parsed_correctly(self):
         """Test that boolean environment variables are parsed correctly."""


### PR DESCRIPTION
src/__init__.py made `src/` itself a package, which combined with the conftest sys.path setup let the same source file be imported twice (`realize.app_metrics` and `src.realize.app_metrics`). Each import re-ran the module body and tried to re-register Prometheus metrics on the global REGISTRY, raising "Duplicated timeseries" during collection of test_metrics, test_metrics_server, test_request_size_limit, and test_streamable_http — and cascading into ~200 downstream failures.

test_missing_env_vars_handled_gracefully relied on deleting REALIZE_* env vars and reloading the config module, but pydantic-settings still loaded credentials from .env, so validation never raised. Switched to a direct Config(_env_file=None) call which exercises the same validator without depending on module-reload semantics or .env masking.