### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,27 +13,37 @@ A Model Context Protocol (MCP) server providing read and write access to Taboola
 
 Connect to the hosted Realize MCP server using [Streamable HTTP](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http) transport with OAuth 2.1. Multi-user, stateless, no local install required.
 
-**Cursor IDE / Claude Desktop** — Add to your MCP client config:
+Pick the section for your client:
 
-```json
-{
-  "mcpServers": {
-    "realize-mcp": {
-      "command": "npx",
-      "args": ["-y", "mcp-remote", "https://mcp.realize.com/mcp"]
-    }
-  }
-}
-```
+### Claude Desktop
 
-**Claude Desktop (UI)**
+Two options — use the UI for the simplest setup, or the config file if you prefer to manage MCP servers as code.
+
+**Option 1 — UI (recommended):**
 
 1. Go to Settings → Connectors → Add Custom Connector
 2. Enter the MCP Server name and URL: `https://mcp.realize.com/mcp`
 3. Select **Connect** to initiate the OAuth 2.1 flow
 4. A browser window will open to Taboola SSO—enter your credentials to obtain a bearer token used by Realize tools
 
-**Claude Code (CLI)**
+**Option 2 — config file:**
+
+Prerequisite: Node.js 18+ (provides `npx`). Install from [nodejs.org](https://nodejs.org) or run `brew install node`.
+
+Add to `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "realize-mcp": {
+      "command": "npx",
+      "args": ["-y", "mcp-remote", "https://mcp.realize.com/mcp", "--port", "3000"]
+    }
+  }
+}
+```
+
+### Claude Code (CLI)
 
 ```bash
 claude mcp add --transport http --callback-port 3000 realize-mcp https://mcp.realize.com/mcp

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ Connect to the hosted Realize MCP server using [Streamable HTTP](https://modelco
 {
   "mcpServers": {
     "realize-mcp": {
-      "url": "https://mcp.realize.com/mcp"
+      "command": "npx",
+      "args": ["-y", "mcp-remote", "https://mcp.realize.com/mcp"]
     }
   }
 }


### PR DESCRIPTION
## Summary
  - Claude Desktop's `claude_desktop_config.json` only accepts stdio-based MCP servers (`command` + `args`); the previous `url`-only entry was rejected with "not a valid MCP server configuration, skipped."
  - Route `realize-mcp` through the `mcp-remote` npm bridge so it runs as a stdio process locally while terminating the Streamable HTTP + OAuth 2.1 flow against `https://mcp.realize.com/mcp`.
  - The upstream README (taboola/realize-mcp) suggests a `url`-only config block for Claude Desktop, but in practice that path only works via Settings → Connectors UI. The bridge approach keeps the server declared in config alongside the other entries.

  ## Changes
  - `claude_desktop_config.json`: replace the `url` field on `realize-mcp` with `command: "npx"` + `args: ["-y", "mcp-remote", "https://mcp.realize.com/mcp"]`.