### PR TITLE
Add VCPM, display item tools, and creative_name support

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,9 @@ branding_text            (string)             Brand name shown with ads
 spending_limit_model     (string enum)        NONE | MONTHLY | ENTIRE
 spending_limit           (number)             Budget amount in account's default currency
 daily_cap                (number)             Daily spend cap
+pricing_model            (string enum)        CPC | VCPM   (default CPC; VCPM requires bid_strategy=FIXED)
 bid_strategy             (string enum)        SMART | FIXED | TARGET_CPA | MAX_CONVERSIONS | MAX_VALUE
-cpc                      (number)             Fixed cost per click (FIXED only)
+cpc                      (number)             Bid amount in account's default currency (per-click for CPC; per-1000-viewable-impressions for VCPM)
 cpa_goal                 (number)             Target cost per acquisition (TARGET_CPA only)
 cpc_cap                  (number)             Upper bound on bids
 start_date               (string)             YYYY-MM-DD
@@ -162,6 +163,7 @@ title          (string, required)            Headline
 description    (string, required)            Body
 thumbnail_url  (string, required)            Image URL
 branding_text  (string)
+creative_name  (string)                      Human-readable creative label shown in the Realize UI
 cta            (object)                      {cta_type} — values from list_cta_types
 ```
 
@@ -176,6 +178,7 @@ title               (string)
 description         (string)
 thumbnail_url       (string)
 branding_text       (string)
+creative_name       (string)                 Human-readable creative label shown in the Realize UI
 is_active           (boolean)                Pause/resume
 cta                 (object)                 {cta_type}
 verification_pixel  (object)                 Tracking pixels (full-replace within block)

--- a/src/realize/config.py
+++ b/src/realize/config.py
@@ -19,6 +19,12 @@ class Config(BaseSettings):
     metrics_enabled: bool = True
     metrics_port: int = 8092
 
+    # === Feature flags ===
+    # Gate display item write tools (create_display_item, update_display_item)
+    # behind an opt-in env var. Default off — MCP clients see only the native
+    # item surface until display rollout is enabled.
+    enable_display_item_tools: bool = False
+
     # === Stdio mode (required when mcp_transport="stdio") ===
     realize_client_id: Optional[str] = None
     realize_client_secret: Optional[str] = None

--- a/src/realize/realize_server.py
+++ b/src/realize/realize_server.py
@@ -95,21 +95,29 @@ async def handle_call_tool(
             from realize.tools.campaign_handlers import update_campaign
             result = await update_campaign(arguments)
 
-        elif handler_path == "item_handlers.list_items":
-            from realize.tools.item_handlers import list_items
+        elif handler_path == "item_read_handlers.list_items":
+            from realize.tools.item_read_handlers import list_items
             result = await list_items(arguments)
 
-        elif handler_path == "item_handlers.get_item":
-            from realize.tools.item_handlers import get_item
+        elif handler_path == "item_read_handlers.get_item":
+            from realize.tools.item_read_handlers import get_item
             result = await get_item(arguments)
 
-        elif handler_path == "item_handlers.create_native_item":
-            from realize.tools.item_handlers import create_native_item
+        elif handler_path == "item_native_handlers.create_native_item":
+            from realize.tools.item_native_handlers import create_native_item
             result = await create_native_item(arguments)
 
-        elif handler_path == "item_handlers.update_native_item":
-            from realize.tools.item_handlers import update_native_item
+        elif handler_path == "item_native_handlers.update_native_item":
+            from realize.tools.item_native_handlers import update_native_item
             result = await update_native_item(arguments)
+
+        elif handler_path == "item_display_handlers.create_display_item":
+            from realize.tools.item_display_handlers import create_display_item
+            result = await create_display_item(arguments)
+
+        elif handler_path == "item_display_handlers.update_display_item":
+            from realize.tools.item_display_handlers import update_display_item
+            result = await update_display_item(arguments)
 
         # Resource discovery handlers
         elif handler_path == "resources.search_geos":

--- a/src/realize/tools/campaign_handlers.py
+++ b/src/realize/tools/campaign_handlers.py
@@ -5,7 +5,7 @@ Read tools (`list_campaigns`, `get_campaign`) plus two write tools —
 (scalars + targeting). All targeting fields ride in a single atomic POST to the
 APICampaign endpoint; one tool call → one HTTP request.
 
-Item-level handlers live in `item_handlers`.
+Item-level handlers live in `item_read_handlers`, `item_native_handlers`, and `item_display_handlers`.
 """
 from typing import Any, Dict, List
 from urllib.parse import quote
@@ -50,7 +50,7 @@ _CREATE_CAMPAIGN_REQUIRED = ("name", "marketing_objective", "branding_text", "sp
 
 _SCALAR_BODY_FIELDS = (
     "name", "marketing_objective", "branding_text", "spending_limit_model",
-    "spending_limit", "daily_cap", "cpc", "bid_strategy", "cpa_goal",
+    "spending_limit", "daily_cap", "cpc", "pricing_model", "bid_strategy", "cpa_goal",
     "start_date", "end_date", "tracking_code", "cpc_cap",
     "daily_ad_delivery_model", "traffic_allocation_mode", "is_active",
 )

--- a/src/realize/tools/item_display_handlers.py
+++ b/src/realize/tools/item_display_handlers.py
@@ -1,0 +1,279 @@
+"""Display item (creative) write handlers for Realize MCP server.
+
+Two write tools (`create_display_item`, `update_display_item`) covering
+display ads attached to a campaign. Two creative modes are supported:
+
+- **Third-party tag** (3P, `display_ad_type=THIRD_PARTY_TAG`): caller supplies
+  raw HTML/JS via `ad_tag` plus a single `dimensions` entry.
+- **Realize-hosted asset by URL** (1P): caller supplies a public https
+  `asset_url` pointing at an image, video, or HTML5 zip. Realize ingests
+  by URL file extension; `dimensions` must be omitted (server populates
+  them from the asset).
+
+`ad_tag` and `asset_url` are mutually exclusive. On update, either field is
+optional (partial-merge); `dimensions` may also be sent alone to update only
+the size of an existing 3P item.
+
+URL-crawled native items live in `item_native_handlers`. Type-agnostic
+read tools (`list_items`, `get_item`) live in `item_read_handlers`.
+"""
+from typing import Any, Dict, List
+from urllib.parse import quote
+
+import mcp.types as types
+
+from realize.client import client
+from realize.tools.errors import ToolInputError
+from realize.tools.utils import format_response, validate_account_id
+from realize.tools.verification_pixel import (
+    sanitize_verification_pixel,
+    validate_verification_pixel,
+)
+from realize.tools.viewability_tag import (
+    sanitize_viewability_tag,
+    validate_viewability_tag,
+)
+
+
+_CREATE_REQUIRED_SCALARS = ("url", "creative_name")
+
+# Top-level scalars carried across both create and update.
+# Display items don't support branding_text or cta — the 3P ad tag handles
+# branding and click itself; for 1P the hosted asset has no separate
+# branding/CTA.
+_CREATE_BODY_FIELDS = ("url",)
+
+_UPDATE_BODY_FIELDS = _CREATE_BODY_FIELDS + ("is_active",)
+
+# Soft cap to catch obvious paste mistakes; structural validation happens
+# server-side in DisplayAdTagValidator on item POST.
+_AD_TAG_MAX_BYTES = 16 * 1024
+
+
+def _validate_ad_tag(value: Any) -> None:
+    if not isinstance(value, str):
+        raise ToolInputError("ad_tag must be a string (raw 3P HTML/JS ad tag)")
+    if not value.strip():
+        raise ToolInputError("ad_tag must be a non-empty string")
+    if len(value.encode("utf-8")) > _AD_TAG_MAX_BYTES:
+        raise ToolInputError(
+            f"ad_tag exceeds {_AD_TAG_MAX_BYTES} bytes; trim or host externally"
+        )
+
+
+def _validate_creative_name(value: Any) -> None:
+    if not isinstance(value, str):
+        raise ToolInputError("creative_name must be a string")
+    if not value.strip():
+        raise ToolInputError("creative_name must be a non-empty string")
+
+
+def _validate_dimensions(value: Any) -> None:
+    # Realize rejects size>1 with 400 ("Only one dimension is allowed for 3rd
+    # party tags"); enforce here for fast feedback.
+    if not isinstance(value, list) or not value:
+        raise ToolInputError(
+            "dimensions must be a non-empty array of {width, height} objects"
+        )
+    if len(value) > 1:
+        raise ToolInputError(
+            "dimensions accepts exactly one {width, height} entry for 3P tags"
+        )
+    for i, dim in enumerate(value):
+        if not isinstance(dim, dict):
+            raise ToolInputError(f"dimensions[{i}] must be an object with width and height")
+        for key in ("width", "height"):
+            v = dim.get(key)
+            # bool is an int subclass — exclude it explicitly.
+            if not isinstance(v, int) or isinstance(v, bool) or v <= 0:
+                raise ToolInputError(
+                    f"dimensions[{i}].{key} must be a positive integer"
+                )
+
+
+def _validate_asset_url(value: Any) -> None:
+    if not isinstance(value, str):
+        raise ToolInputError("asset_url must be a string")
+    if not value.strip():
+        raise ToolInputError("asset_url must be a non-empty string")
+    if not value.startswith("https://"):
+        raise ToolInputError(
+            "asset_url must be an https URL — Realize only accepts https sources"
+        )
+
+
+def _sanitize_dimensions(value: List[Dict[str, Any]]) -> List[Dict[str, int]]:
+    return [{"width": d["width"], "height": d["height"]} for d in value]
+
+
+def _build_display_payload(args: Dict[str, Any], *, is_create: bool) -> Dict[str, Any]:
+    """Validate and assemble the display-item POST body.
+
+    `ad_tag` and `asset_url` are mutually exclusive. When `asset_url` is set,
+    the payload uses `display_data.hosted_display_data.asset_url` and Realize
+    ingests the asset server-side; `dimensions` must be absent. Otherwise the
+    payload uses `display_data.{ad_tag,dimensions}` per the existing 3P flow.
+
+    On update either branch's fields are individually optional (partial-merge);
+    on create the caller must supply exactly one discriminator and the
+    matching companion fields.
+
+    Server infers `creative_type` (always DISPLAY) and
+    `display_data.display_ad_type` from payload shape; both are read-only and
+    rejected with 400 if sent.
+    """
+    body: Dict[str, Any] = {}
+
+    scalar_fields = _CREATE_BODY_FIELDS if is_create else _UPDATE_BODY_FIELDS
+    for f in scalar_fields:
+        if args.get(f) is not None:
+            body[f] = args[f]
+
+    # Normalize blank strings to None so the mutex and required checks agree:
+    # _check_create_required treats "" as missing (via truthy), while the rest
+    # of this function would otherwise treat "" as set (via is-not-None).
+    ad_tag = args.get("ad_tag")
+    if isinstance(ad_tag, str) and not ad_tag.strip():
+        ad_tag = None
+
+    asset_url = args.get("asset_url")
+    if isinstance(asset_url, str) and not asset_url.strip():
+        asset_url = None
+
+    dimensions = args.get("dimensions")
+
+    if asset_url is not None and ad_tag is not None:
+        raise ToolInputError(
+            "ad_tag and asset_url are mutually exclusive — provide only one"
+        )
+
+    display_data: Dict[str, Any] = {}
+
+    if asset_url is not None:
+        _validate_asset_url(asset_url)
+        if dimensions is not None:
+            raise ToolInputError(
+                "dimensions is not accepted with asset_url — Realize populates "
+                "dimensions from the hosted asset"
+            )
+        display_data["hosted_display_data"] = {"asset_url": asset_url}
+    else:
+        if ad_tag is not None:
+            _validate_ad_tag(ad_tag)
+            display_data["ad_tag"] = ad_tag
+        if dimensions is not None:
+            _validate_dimensions(dimensions)
+            display_data["dimensions"] = _sanitize_dimensions(dimensions)
+
+    if display_data:
+        body["display_data"] = display_data
+
+    creative_name = args.get("creative_name")
+    if creative_name is not None:
+        _validate_creative_name(creative_name)
+        body["custom_data"] = {"creative_name": creative_name}
+
+    if not is_create:
+        verification_pixel = args.get("verification_pixel")
+        if verification_pixel is not None:
+            validate_verification_pixel(verification_pixel)
+            body["verification_pixel"] = sanitize_verification_pixel(verification_pixel)
+
+        viewability_tag = args.get("viewability_tag")
+        if viewability_tag is not None:
+            validate_viewability_tag(viewability_tag)
+            body["viewability_tag"] = sanitize_viewability_tag(viewability_tag)
+
+    return body
+
+
+def _check_create_required(args: Dict[str, Any]) -> None:
+    """Build the create-time missing-field error.
+
+    Always-required scalars (url, creative_name) plus the discriminator
+    requirement (exactly one of ad_tag or asset_url; if ad_tag, also
+    dimensions). Pooling these into one ``Missing required field(s)`` error
+    matches the prior 3P-only behavior and keeps client-side feedback
+    compact when multiple fields are missing at once.
+    """
+    missing: List[str] = []
+    for field in _CREATE_REQUIRED_SCALARS:
+        if not args.get(field):
+            missing.append(field)
+
+    has_ad_tag = bool(args.get("ad_tag"))
+    has_asset_url = bool(args.get("asset_url"))
+
+    if not has_ad_tag and not has_asset_url:
+        missing.append("ad_tag or asset_url")
+    elif has_ad_tag and not args.get("dimensions"):
+        missing.append("dimensions")
+
+    if missing:
+        raise ToolInputError(f"Missing required field(s): {', '.join(missing)}")
+
+
+async def create_display_item(arguments: dict = None) -> List[types.TextContent]:
+    """Create a display item directly attached to a campaign (3P tag or 1P hosted URL)."""
+    args = arguments or {}
+    account_id = args.get("account_id")
+    campaign_id = args.get("campaign_id")
+
+    is_valid, error_message = validate_account_id(account_id)
+    if not is_valid:
+        raise ToolInputError(error_message)
+
+    if not campaign_id:
+        raise ToolInputError("campaign_id is required")
+
+    _check_create_required(args)
+
+    payload = _build_display_payload(args, is_create=True)
+
+    # Mass endpoint accepts the full payload via APICollection<APICampaignItem>;
+    # wrap the single item and unwrap results[0] for callers, matching the
+    # native create flow.
+    response = await client.post(
+        f"/{quote(account_id, safe='')}/campaigns/{quote(campaign_id, safe='')}/items/mass",
+        data={"collection": [payload]},
+    )
+    item = response["results"][0] if isinstance(response, dict) and response.get("results") else response
+
+    return [types.TextContent(
+        type="text",
+        text=f"Display item created on campaign {campaign_id}:\n{format_response(item)}",
+    )]
+
+
+async def update_display_item(arguments: dict = None) -> List[types.TextContent]:
+    """Update an existing display item (partial-merge for scalars and display_data)."""
+    args = arguments or {}
+    account_id = args.get("account_id")
+    campaign_id = args.get("campaign_id")
+    item_id = args.get("item_id")
+
+    is_valid, error_message = validate_account_id(account_id)
+    if not is_valid:
+        raise ToolInputError(error_message)
+
+    if not campaign_id:
+        raise ToolInputError("campaign_id is required")
+
+    if not item_id:
+        raise ToolInputError("item_id is required")
+
+    payload = _build_display_payload(args, is_create=False)
+
+    if not payload:
+        raise ToolInputError("at least one updatable field must be supplied")
+
+    response = await client.post(
+        f"/{quote(account_id, safe='')}/campaigns/{quote(campaign_id, safe='')}"
+        f"/items/{quote(item_id, safe='')}",
+        data=payload,
+    )
+
+    return [types.TextContent(
+        type="text",
+        text=f"Display item {item_id} updated:\n{format_response(response)}",
+    )]

--- a/src/realize/tools/item_native_handlers.py
+++ b/src/realize/tools/item_native_handlers.py
@@ -1,9 +1,10 @@
-"""Item (creative) handlers for Realize MCP server.
+"""Native item (creative) write handlers for Realize MCP server.
 
-Read tools (`list_items`, `get_item`) plus two write tools
-(`create_native_item`, `update_native_item`) covering creatives directly
-attached to a campaign. Native `ITEM` type only — RSS feed items, motion
-ads / performance video, display, and hierarchy carousel are out of scope.
+Two native write tools (`create_native_item`, `update_native_item`) covering
+URL-crawled creatives directly attached to a campaign. Native `ITEM` type
+only — RSS feed items, motion ads / performance video, and hierarchy carousel
+are out of scope. Third-party display ads live in `item_display_handlers`.
+Type-agnostic read tools (`list_items`, `get_item`) live in `item_read_handlers`.
 """
 from typing import Any, Dict, List
 from urllib.parse import quote
@@ -34,50 +35,11 @@ _CREATE_BODY_FIELDS = (
 _UPDATE_BODY_FIELDS = _CREATE_BODY_FIELDS + ("is_active",)
 
 
-async def list_items(arguments: dict = None) -> List[types.TextContent]:
-    """List all items for a campaign (read-only)."""
-    account_id = arguments.get("account_id") if arguments else None
-    campaign_id = arguments.get("campaign_id") if arguments else None
-
-    is_valid, error_message = validate_account_id(account_id)
-    if not is_valid:
-        raise ToolInputError(error_message)
-
-    if not campaign_id:
-        raise ToolInputError("campaign_id is required")
-
-    response = await client.get(
-        f"/{quote(account_id, safe='')}/campaigns/{quote(campaign_id, safe='')}/items"
-    )
-
-    return [types.TextContent(
-        type="text",
-        text=f"Campaign items for campaign {campaign_id}:\n{format_response(response)}",
-    )]
-
-
-async def get_item(arguments: dict = None) -> List[types.TextContent]:
-    """Get specific campaign item details (read-only)."""
-    account_id = arguments.get("account_id") if arguments else None
-    campaign_id = arguments.get("campaign_id") if arguments else None
-    item_id = arguments.get("item_id") if arguments else None
-
-    is_valid, error_message = validate_account_id(account_id)
-    if not is_valid:
-        raise ToolInputError(error_message)
-
-    if not campaign_id or not item_id:
-        raise ToolInputError("campaign_id and item_id are both required")
-
-    response = await client.get(
-        f"/{quote(account_id, safe='')}/campaigns/{quote(campaign_id, safe='')}"
-        f"/items/{quote(item_id, safe='')}"
-    )
-
-    return [types.TextContent(
-        type="text",
-        text=f"Campaign item {item_id} details:\n{format_response(response)}",
-    )]
+def _validate_creative_name(value: Any) -> None:
+    if not isinstance(value, str):
+        raise ToolInputError("creative_name must be a string")
+    if not value.strip():
+        raise ToolInputError("creative_name must be a non-empty string")
 
 
 def _build_item_payload(args: Dict[str, Any], *, is_create: bool) -> Dict[str, Any]:
@@ -94,6 +56,11 @@ def _build_item_payload(args: Dict[str, Any], *, is_create: bool) -> Dict[str, A
     for f in scalar_fields:
         if args.get(f) is not None:
             body[f] = args[f]
+
+    creative_name = args.get("creative_name")
+    if creative_name is not None:
+        _validate_creative_name(creative_name)
+        body["custom_data"] = {"creative_name": creative_name}
 
     cta = args.get("cta")
     if cta is not None:

--- a/src/realize/tools/item_read_handlers.py
+++ b/src/realize/tools/item_read_handlers.py
@@ -1,0 +1,61 @@
+"""Type-agnostic item read handlers for Realize MCP server.
+
+`list_items` and `get_item` return whatever items live on a campaign —
+native, display, or any other supported type — without filtering. Write
+handlers split by type live in `item_native_handlers` and
+`item_display_handlers`.
+"""
+from typing import List
+from urllib.parse import quote
+
+import mcp.types as types
+
+from realize.client import client
+from realize.tools.errors import ToolInputError
+from realize.tools.utils import format_response, validate_account_id
+
+
+async def list_items(arguments: dict = None) -> List[types.TextContent]:
+    """List all items for a campaign (read-only)."""
+    account_id = arguments.get("account_id") if arguments else None
+    campaign_id = arguments.get("campaign_id") if arguments else None
+
+    is_valid, error_message = validate_account_id(account_id)
+    if not is_valid:
+        raise ToolInputError(error_message)
+
+    if not campaign_id:
+        raise ToolInputError("campaign_id is required")
+
+    response = await client.get(
+        f"/{quote(account_id, safe='')}/campaigns/{quote(campaign_id, safe='')}/items"
+    )
+
+    return [types.TextContent(
+        type="text",
+        text=f"Campaign items for campaign {campaign_id}:\n{format_response(response)}",
+    )]
+
+
+async def get_item(arguments: dict = None) -> List[types.TextContent]:
+    """Get specific campaign item details (read-only)."""
+    account_id = arguments.get("account_id") if arguments else None
+    campaign_id = arguments.get("campaign_id") if arguments else None
+    item_id = arguments.get("item_id") if arguments else None
+
+    is_valid, error_message = validate_account_id(account_id)
+    if not is_valid:
+        raise ToolInputError(error_message)
+
+    if not campaign_id or not item_id:
+        raise ToolInputError("campaign_id and item_id are both required")
+
+    response = await client.get(
+        f"/{quote(account_id, safe='')}/campaigns/{quote(campaign_id, safe='')}"
+        f"/items/{quote(item_id, safe='')}"
+    )
+
+    return [types.TextContent(
+        type="text",
+        text=f"Campaign item {item_id} details:\n{format_response(response)}",
+    )]

--- a/src/realize/tools/registry.py
+++ b/src/realize/tools/registry.py
@@ -1,7 +1,7 @@
 """Centralized registry for all MCP tools.
 
 ================================================================================
-TOOL SURFACE — 23 tools across 6 categories
+TOOL SURFACE — 25 tools across 6 categories
 ================================================================================
 
 Authentication (stdio transport only; excluded in HTTP/OAuth mode):
@@ -22,8 +22,10 @@ Campaigns (write — fat tools, all targeting inline, single atomic POST):
 Items:
   - list_items                           (read)
   - get_item                             (read)
-  - create_native_item                   (write — native ITEM only)
+  - create_native_item                   (write — URL-crawled native ITEM)
   - update_native_item                   (write — partial-merge scalars; full-replace verification_pixel / viewability_tag arrays)
+  - create_display_item                  (write — 3P third-party ad tag or 1P Realize-hosted asset URL)
+  - update_display_item                  (write — partial-merge scalars + display_data; full-replace verification_pixel / viewability_tag arrays)
 
 Discovery (resources for resolving IDs/names used in campaign + item payloads):
   - search_geos                          (countries / regions / dma / cities / postal_codes)
@@ -479,7 +481,12 @@ _SCALAR_PROPERTIES = {
     },
     "spending_limit": {"type": "number", "description": "Budget amount in account's default currency."},
     "daily_cap": {"type": "number", "description": "Daily spend cap in account's default currency. Only valid when daily_ad_delivery_model=STRICT; rejected with BALANCED."},
-    "cpc": {"type": "number", "description": "Fixed cost per click in account's default currency."},
+    "cpc": {"type": "number", "description": "Bid amount in account's default currency. With pricing_model=CPC, charged per click. With pricing_model=VCPM, this value is the per-1000-viewable-impression bid (server-enforced range applies)."},
+    "pricing_model": {
+        "type": "string",
+        "enum": ["CPC", "VCPM"],
+        "description": "Pricing model. CPC (default) charges per click. VCPM charges per 1000 viewable impressions; the `cpc` field carries the vCPM rate. VCPM requires bid_strategy=FIXED.",
+    },
     "bid_strategy": {
         "type": "string",
         "enum": ["SMART", "FIXED", "TARGET_CPA", "MAX_CONVERSIONS", "MAX_VALUE"],
@@ -555,6 +562,8 @@ Conditional rules:
 - bid_strategy = MAX_CONVERSIONS → cpc_cap allowed. Other strategies → omit cpc_cap.
 - marketing_objective = BRAND_AWARENESS|DRIVE_WEBSITE_TRAFFIC → send cpc; bid_strategy SMART (default) or FIXED; omit cpa_goal.
 - marketing_objective = LEADS_GENERATION|ONLINE_PURCHASES|MOBILE_APP_INSTALL → bid_strategy = TARGET_CPA|MAX_CONVERSIONS|MAX_VALUE; if TARGET_CPA also send cpa_goal; omit cpc.
+- pricing_model = VCPM → bid_strategy MUST be FIXED; cpc carries the vCPM rate; omit cpc_cap and cpa_goal; traffic_allocation_mode is forced to OPTIMIZED server-side.
+- pricing_model omitted → server defaults to CPC.
 - If both start_date and end_date sent: end_date >= start_date.
 
 Discovery (call before constructing the payload to resolve IDs/names):
@@ -567,7 +576,7 @@ Discovery (call before constructing the payload to resolve IDs/names):
 - search_conversion_rules → `conversion_rules.rules` IDs.
 - list_time_zones → `activity_schedule.time_zone` IANA names.
 
-Read-only — NEVER send: id, advertiser_id, status, approval_state, spent, policy_review, pricing_model, target_cpa, target_cpa_learning_status. (`target_cpa` is server-recommended; user goal is `cpa_goal`.)
+Read-only — NEVER send: id, advertiser_id, status, approval_state, spent, policy_review, target_cpa, target_cpa_learning_status. (`target_cpa` is server-recommended; user goal is `cpa_goal`.)
 
 All targeting (including audiences, lookalike, contextual segments) goes in one atomic call; either the whole campaign with all targeting commits, or none of it does.
 
@@ -650,6 +659,7 @@ Conditional rules (apply only when the gating field is in this request):
 - daily_ad_delivery_model = STRICT → also send daily_cap. BALANCED → omit daily_cap.
 - bid_strategy = MAX_CONVERSIONS → cpc_cap allowed. Other strategies → omit cpc_cap.
 - bid_strategy = TARGET_CPA → also send cpa_goal.
+- pricing_model = VCPM → bid_strategy MUST be FIXED; cpc carries the vCPM rate; omit cpc_cap and cpa_goal; traffic_allocation_mode is forced to OPTIMIZED server-side.
 - If both start_date and end_date sent: end_date >= start_date.
 - Solo updates of a partner field (e.g. only spending_limit, or only cpa_goal) are allowed — stored gating field is reused.
 
@@ -665,7 +675,7 @@ Discovery: same as create_campaign — search_geos, search_techno, search_audien
 
 Field shapes are identical to create_campaign — see its comprehensive example for every targeting block. Examples below focus on update-only patterns (partial-merge, classic-geo, full-replace within a section).
 
-Read-only — NEVER send: id, advertiser_id, status, approval_state, spent, policy_review, pricing_model, target_cpa, target_cpa_learning_status.
+Read-only — NEVER send: id, advertiser_id, status, approval_state, spent, policy_review, target_cpa, target_cpa_learning_status.
 
 All updates (including audiences, lookalike, contextual segments) go in one atomic call.
 
@@ -742,6 +752,10 @@ _ITEM_SCALAR_PROPERTIES_CREATE = {
         "type": "string",
         "description": "Brand name shown with the ad. Inherits from campaign if omitted.",
     },
+    "creative_name": {
+        "type": "string",
+        "description": "Human-readable creative label shown in the Realize UI. Optional passthrough — Realize does not validate length.",
+    },
 }
 
 
@@ -770,7 +784,7 @@ Create a native item directly attached to a campaign on Realize. "Item", "ad", a
 
 Prerequisites: call search_accounts to obtain `account_id`; call list_campaigns or get_campaign to obtain `campaign_id`. Numeric account IDs are rejected.
 
-Scope: this tool creates a native `ITEM` directly attached to the campaign. RSS feed items, motion ads, performance video items, display creatives, hierarchy carousel items, and the Creative Library are not supported.
+Scope: this tool creates a native `ITEM` directly attached to the campaign. For third-party display ads (banner ad tag with fixed dimensions) or first-party Realize-hosted assets (image/video/HTML5 zip URL), use create_display_item. RSS feed items, motion ads, performance video items, hierarchy carousel items, and the Creative Library are not supported.
 
 Discovery (call before constructing the payload to resolve IDs/names):
 - list_cta_types → `cta.cta_type` allowed values.
@@ -779,7 +793,7 @@ Read-only — NEVER send: id, campaign_id (set via path), type, status, approval
 
 Item creation goes in one atomic call; either the item commits with all fields, or it doesn't.
 
-Required fields: `account_id`, `campaign_id`, `url`, `title`, `description`, `thumbnail_url`. Optional: `branding_text`, `cta`. New items typically transition PENDING_APPROVAL → RUNNING.
+Required fields: `account_id`, `campaign_id`, `url`, `title`, `description`, `thumbnail_url`. Optional: `branding_text`, `creative_name`, `cta`. New items typically transition PENDING_APPROVAL → RUNNING.
 
 Plain English: a "Spring Sale" creative for the Acme brand, landing at example.com/landing, with explicit headline / body / thumbnail and Shop Now CTA. New items are always created active; use update_native_item to pause if needed.
 
@@ -795,6 +809,7 @@ _CREATE_CAMPAIGN_ITEM_JSON_EXAMPLE = """\
   "description": "Limited-time offer on all spring collection items.",
   "thumbnail_url": "https://cdn.example.com/spring.jpg",
   "branding_text": "Acme",
+  "creative_name": "Acme Spring Sale Native",
   "cta": {"cta_type": "SHOP_NOW"}
 }"""
 
@@ -813,7 +828,7 @@ Array semantics — FULL-REPLACE within section: sending `verification_pixel` or
 
 Editability: items in PENDING_APPROVAL accept full edits. Items in RUNNING / PAUSED practically only accept `is_active` toggles and minor metadata; the API surfaces 4xx for non-allowed transitions. REJECTED items cannot be edited — recreate.
 
-Scope: native `ITEM` only. RSS feed items, motion ads, performance video, display, hierarchy carousel, and the Creative Library are not supported.
+Scope: native `ITEM` only — for editing third-party display ads or 1P hosted assets use update_display_item. RSS feed items, motion ads, performance video, hierarchy carousel, and the Creative Library are not supported.
 
 Discovery (call before constructing the payload to resolve IDs/names):
 - list_cta_types → `cta.cta_type` allowed values.
@@ -841,6 +856,7 @@ _UPDATE_CAMPAIGN_ITEM_JSON_EXAMPLE = """\
   "description": "Spring sale extended through end of June.",
   "thumbnail_url": "https://cdn.example.com/spring-v2.jpg",
   "branding_text": "Acme",
+  "creative_name": "Acme Spring Sale Native — v2",
   "cta": {"cta_type": "LEARN_MORE"},
   "is_active": true,
   "verification_pixel": {
@@ -896,6 +912,231 @@ _UPDATE_CAMPAIGN_ITEM_PROPERTIES = {
     **_ITEM_SCALAR_PROPERTIES_CREATE,
     **_ITEM_SCALAR_PROPERTIES_UPDATE_EXTRAS,
     **_ITEM_NESTED_PROPERTIES_UPDATE,
+}
+
+
+# 4.5b Display-item — schemas, prose, and composed property maps for the
+# display creative tools (`create_display_item` / `update_display_item`).
+# Supports two creative modes: 3P (ad_tag + dimensions) and 1P (asset_url).
+
+_DISPLAY_AD_TAG_SCHEMA = {
+    "type": "string",
+    "description": """\
+Third-party (3P) mode. Raw HTML/JS ad tag (e.g. Google Ad Manager, Xandr,
+Equativ). Realize validates structure server-side and performs ${CLICK_URL}
+macro replacement on submit. Soft 16 KiB cap. Mutually exclusive with
+asset_url — pass exactly one.""",
+}
+
+
+_DISPLAY_DIMENSIONS_SCHEMA = {
+    "type": "array",
+    "description": """\
+Single ad size for a 3P tag, wrapped in a one-entry array, e.g.
+[{"width": 300, "height": 250}]. Required when ad_tag is provided; forbidden
+when asset_url is provided (Realize auto-populates dimensions from the
+hosted asset). Exactly one entry — Realize rejects multi-size arrays for 3P
+tags with a 400. Common IAB sizes: 300x250, 728x90, 160x600, 300x600,
+970x90, 970x250, 468x60. On update, sending this field replaces the prior
+dimension.""",
+    "items": {
+        "type": "object",
+        "properties": {
+            "width": {"type": "integer", "minimum": 1},
+            "height": {"type": "integer", "minimum": 1},
+        },
+        "required": ["width", "height"],
+    },
+    "minItems": 1,
+    "maxItems": 1,
+}
+
+
+_DISPLAY_ASSET_URL_SCHEMA = {
+    "type": "string",
+    "description": """\
+First-party (1P) mode. Public https URL of a creative asset for Realize to
+ingest. Supported types (chosen by URL file extension):
+  - Image: .jpg, .jpeg, .png, .gif, .bmp, .webp
+  - Video: .mp4, .mpg, .mpeg, .flv, .webm
+  - HTML5 bundle: .zip (origin must serve `Content-Type: application/zip`)
+Must be https. Max 200 MB. Mutually exclusive with ad_tag — pass exactly
+one. Do not send dimensions with asset_url; Realize populates them from
+the asset.""",
+}
+
+
+_DISPLAY_ITEM_SCALAR_PROPERTIES = {
+    "url": {
+        "type": "string",
+        "description": "Landing page URL the ad clicks through to. Required on create.",
+    },
+    "creative_name": {
+        "type": "string",
+        "description": "Human-readable creative label shown in the Realize UI. Required on create for display items; passthrough — Realize does not validate length.",
+    },
+}
+
+
+_CREATE_DISPLAY_ITEM_PROSE = """\
+Create a display item directly attached to a campaign on Realize. "Item", "ad", and "creative" all refer to the same object — this tool creates one. Returns the created item with its server-assigned `id`, `status`, and `approval_state`.
+
+Prerequisites: call search_accounts to obtain `account_id`; call list_campaigns or get_campaign to obtain `campaign_id`. Numeric account IDs are rejected.
+
+Two creative modes — pass exactly one discriminator:
+  - Third-party (3P) tag: send `ad_tag` (raw HTML/JS) + `dimensions`. Realize validates structure server-side and performs ${CLICK_URL} macro replacement on submit. Soft 16 KiB cap client-side.
+  - First-party (1P) Realize-hosted asset: send `asset_url` (public https URL). Realize ingests by URL file extension — image (jpg/jpeg/png/gif/bmp/webp), video (mp4/mpg/mpeg/flv/webm), or HTML5 bundle (zip; origin must serve `Content-Type: application/zip`). Do NOT send `dimensions` with `asset_url`; Realize populates them from the asset. Max 200 MB.
+
+For URL-crawled native items use create_native_item instead. HOSTED_SOCIAL is not currently supported.
+
+Not applicable to display creatives: `branding_text` and `cta` — the ad tag or hosted asset handles its own branding and click; sending these has no effect.
+
+Read-only — NEVER send: id, campaign_id (set via path), creative_type (server enforces DISPLAY), display_data.display_ad_type (server-detected), status, approval_state, learning_state, policy_review.
+
+Item creation goes in one atomic call; either the item commits with all fields, or it doesn't.
+
+Comprehensive examples (only `account_id`, `campaign_id`, `url`, `creative_name`, and exactly one of `ad_tag` or `asset_url` are mandatory). New items are always created active; use update_display_item to pause if needed.
+
+"""
+
+
+_CREATE_DISPLAY_ITEM_JSON_EXAMPLE = """\
+Example — 3P tag (300x250 CM360 banner):
+{
+  "account_id": "acme-inc",
+  "campaign_id": "49184816",
+  "url": "https://example.com/landing",
+  "ad_tag": "<ins class=\\"dcmads\\" style=\\"display:inline-block;width:300px;height:250px\\" data-dcm-placement=\\"N12345.1234567ACME/B12345678.123456789\\" data-dcm-rendering-mode=\\"script\\" data-dcm-https-only data-dcm-resettable-device-id=\\"\\" data-dcm-app-id=\\"\\" data-dcm-click-tracker=\\"${CLICK_URL}\\"><script src=\\"https://www.googletagservices.com/dcm/dcmads.js\\"></script></ins>",
+  "dimensions": [{"width": 300, "height": 250}],
+  "creative_name": "Acme Spring Sale 300x250"
+}
+
+Example — 1P hosted image (image type chosen from .png extension):
+{
+  "account_id": "acme-inc",
+  "campaign_id": "49184816",
+  "url": "https://example.com/landing",
+  "asset_url": "https://cdn.example.com/creatives/acme-spring-300x250.png",
+  "creative_name": "Acme Spring Sale 300x250 — hosted image"
+}
+
+Example — 1P HTML5 bundle (.zip URL; origin must serve `Content-Type: application/zip`):
+{
+  "account_id": "acme-inc",
+  "campaign_id": "49184816",
+  "url": "https://example.com/landing",
+  "asset_url": "https://cdn.example.com/creatives/acme-spring-300x250.zip",
+  "creative_name": "Acme Spring Sale 300x250 — html5"
+}"""
+
+
+_CREATE_DISPLAY_ITEM_DESCRIPTION = _CREATE_DISPLAY_ITEM_PROSE + _CREATE_DISPLAY_ITEM_JSON_EXAMPLE
+
+
+_UPDATE_DISPLAY_ITEM_PROSE = """\
+Update an existing display item: top-level scalars, the `display_data` block, and any nested block (verification_pixel, viewability_tag) in one call. "Item", "ad", and "creative" all refer to the same object — this tool updates one.
+
+Prerequisites: call search_accounts (`account_id`), list_campaigns or get_campaign (`campaign_id`), list_items or get_item (`item_id`). Numeric account IDs are rejected.
+
+Partial-merge for scalars: fields omitted from the request keep their prior value. The creative discriminator on update follows the same mutex as create — send at most one of `ad_tag` or `asset_url`:
+  - `ad_tag` (3P) swaps the tag. `dimensions` is required when ad_tag is sent and replaces the prior dimension.
+  - `asset_url` (1P) replaces the hosted asset; Realize re-ingests by URL file extension. Do NOT send `dimensions` with `asset_url`.
+Items created in one mode generally cannot be flipped to the other; the server rejects mode-switch attempts with a 4xx.
+
+Array semantics — FULL-REPLACE within section: sending `verification_pixel` or `viewability_tag` overwrites the entire prior list for that field. Send [] to clear. To edit one entry, read with get_item, modify locally, send the merged result.
+
+Editability: items in CRAWLING / PENDING_APPROVAL accept full edits. Items in RUNNING / PAUSED practically only accept `is_active` toggles and minor metadata; the API surfaces 4xx for non-allowed transitions. REJECTED items cannot be edited — recreate.
+
+Scope: display items only — for editing URL-crawled native items use update_native_item. HOSTED_SOCIAL, RSS feed items, motion ads, performance video, hierarchy carousel, and the Creative Library are not supported.
+
+Not applicable to display creatives: `branding_text` and `cta` — the ad tag or hosted asset handles its own branding and click; sending these has no effect.
+
+Read-only — NEVER send: id, campaign_id (set via path), creative_type, display_data.display_ad_type, status, approval_state, learning_state, policy_review.
+
+At least one updatable field besides account_id, campaign_id, and item_id must be sent.
+
+All updates (including verification_pixel and viewability_tag) go in one atomic call.
+
+Comprehensive examples (only `account_id`, `campaign_id`, and `item_id` are mandatory, plus at least one updatable field).
+
+"""
+
+
+_UPDATE_DISPLAY_ITEM_JSON_EXAMPLE = """\
+{
+  "account_id": "acme-inc",
+  "campaign_id": "49184816",
+  "item_id": "987654321",
+  "url": "https://example.com/landing-v2",
+  "ad_tag": "<ins class=\\"dcmads\\" style=\\"display:inline-block;width:300px;height:250px\\" data-dcm-placement=\\"N12345.1234567ACME/B12345678.123456789\\" data-dcm-rendering-mode=\\"script\\" data-dcm-https-only data-dcm-resettable-device-id=\\"\\" data-dcm-app-id=\\"\\" data-dcm-click-tracker=\\"${CLICK_URL}\\"><script src=\\"https://www.googletagservices.com/dcm/dcmads.js\\"></script></ins>",
+  "dimensions": [{"width": 300, "height": 250}],
+  "creative_name": "Acme Spring Sale 300x250 — v2",
+  "is_active": true,
+  "verification_pixel": {
+    "verification_pixel_items": [
+      {"url": "https://verifier.example.com/c?x=1", "verification_pixel_type": "CLICK"},
+      {"url": "https://verifier.example.com/v?x=1", "verification_pixel_type": "VIEWABLE_IMPRESSION"}
+    ]
+  },
+  "viewability_tag": {
+    "values": [
+      {"tag": "<noscript class=...></noscript><script src=...></script>", "type": "IAS"}
+    ]
+  }
+}
+
+Example — pause display item (partial-merge, scalars only):
+{ "account_id": "acme-inc", "campaign_id": "49184816", "item_id": "987654321", "is_active": false }
+
+Example — swap ad tag without touching dimensions (display_data partial-merge):
+{ "account_id": "acme-inc", "campaign_id": "49184816", "item_id": "987654321", "ad_tag": "<script>...new tag...</script>" }
+
+Example — swap the hosted asset on a 1P item (re-ingest from new URL):
+{ "account_id": "acme-inc", "campaign_id": "49184816", "item_id": "987654321", "asset_url": "https://cdn.example.com/creatives/acme-spring-300x250-v2.png" }
+
+Example — clear all verification pixels (full-replace within section):
+{ "account_id": "acme-inc", "campaign_id": "49184816", "item_id": "987654321", "verification_pixel": {"verification_pixel_items": []} }"""
+
+
+_UPDATE_DISPLAY_ITEM_DESCRIPTION = _UPDATE_DISPLAY_ITEM_PROSE + _UPDATE_DISPLAY_ITEM_JSON_EXAMPLE
+
+
+_CREATE_DISPLAY_ITEM_PROPERTIES = {
+    "account_id": {
+        "type": "string",
+        "description": "Value from search_accounts.account_id (NOT numeric).",
+    },
+    "campaign_id": {
+        "type": "string",
+        "description": "Value from list_campaigns.id or get_campaign.id (returned by create_campaign as `id`). Numeric ID as a string (e.g. \"49184816\").",
+    },
+    **_DISPLAY_ITEM_SCALAR_PROPERTIES,
+    "ad_tag": _DISPLAY_AD_TAG_SCHEMA,
+    "dimensions": _DISPLAY_DIMENSIONS_SCHEMA,
+    "asset_url": _DISPLAY_ASSET_URL_SCHEMA,
+}
+
+
+_UPDATE_DISPLAY_ITEM_PROPERTIES = {
+    "account_id": {
+        "type": "string",
+        "description": "Value from search_accounts.account_id (NOT numeric).",
+    },
+    "campaign_id": {
+        "type": "string",
+        "description": "Value from list_campaigns.id or get_campaign.id. Numeric ID as a string (e.g. \"49184816\").",
+    },
+    "item_id": {
+        "type": "string",
+        "description": "Value from list_items.id or get_item.id. Numeric ID as a string (e.g. \"987654321\").",
+    },
+    **_DISPLAY_ITEM_SCALAR_PROPERTIES,
+    "ad_tag": _DISPLAY_AD_TAG_SCHEMA,
+    "dimensions": _DISPLAY_DIMENSIONS_SCHEMA,
+    "asset_url": _DISPLAY_ASSET_URL_SCHEMA,
+    **_ITEM_SCALAR_PROPERTIES_UPDATE_EXTRAS,
+    "verification_pixel": _ITEM_VERIFICATION_PIXEL_SCHEMA,
+    "viewability_tag": _ITEM_VIEWABILITY_TAG_SCHEMA,
 }
 
 
@@ -1057,7 +1298,7 @@ _CAMPAIGN_ITEM_TOOLS = {
             },
             "required": ["account_id", "campaign_id"]
         },
-        "handler": "item_handlers.list_items",
+        "handler": "item_read_handlers.list_items",
         "category": "items"
     },
 
@@ -1081,7 +1322,7 @@ _CAMPAIGN_ITEM_TOOLS = {
             },
             "required": ["account_id", "campaign_id", "item_id"]
         },
-        "handler": "item_handlers.get_item",
+        "handler": "item_read_handlers.get_item",
         "category": "items"
     },
 
@@ -1092,7 +1333,7 @@ _CAMPAIGN_ITEM_TOOLS = {
             "properties": _CREATE_CAMPAIGN_ITEM_PROPERTIES,
             "required": ["account_id", "campaign_id", "url", "title", "description", "thumbnail_url"],
         },
-        "handler": "item_handlers.create_native_item",
+        "handler": "item_native_handlers.create_native_item",
         "category": "items",
         "annotations": _DESTRUCTIVE_ANNOTATIONS_CREATE,
     },
@@ -1104,7 +1345,31 @@ _CAMPAIGN_ITEM_TOOLS = {
             "properties": _UPDATE_CAMPAIGN_ITEM_PROPERTIES,
             "required": ["account_id", "campaign_id", "item_id"],
         },
-        "handler": "item_handlers.update_native_item",
+        "handler": "item_native_handlers.update_native_item",
+        "category": "items",
+        "annotations": _DESTRUCTIVE_ANNOTATIONS_UPDATE,
+    },
+
+    "create_display_item": {
+        "description": _CREATE_DISPLAY_ITEM_DESCRIPTION,
+        "schema": {
+            "type": "object",
+            "properties": _CREATE_DISPLAY_ITEM_PROPERTIES,
+            "required": ["account_id", "campaign_id", "url", "creative_name"],
+        },
+        "handler": "item_display_handlers.create_display_item",
+        "category": "items",
+        "annotations": _DESTRUCTIVE_ANNOTATIONS_CREATE,
+    },
+
+    "update_display_item": {
+        "description": _UPDATE_DISPLAY_ITEM_DESCRIPTION,
+        "schema": {
+            "type": "object",
+            "properties": _UPDATE_DISPLAY_ITEM_PROPERTIES,
+            "required": ["account_id", "campaign_id", "item_id"],
+        },
+        "handler": "item_display_handlers.update_display_item",
         "category": "items",
         "annotations": _DESTRUCTIVE_ANNOTATIONS_UPDATE,
     },
@@ -1582,14 +1847,20 @@ TOOL_REGISTRY = {
 # 6. Public accessors
 # ============================================================================
 
+_DISPLAY_ITEM_TOOL_NAMES = frozenset({"create_display_item", "update_display_item"})
+
+
 def get_all_tools():
-    """Get all registered tools, filtered by transport mode."""
+    """Get all registered tools, filtered by transport mode and feature flags."""
     from realize.config import config
 
     tools = TOOL_REGISTRY
     if config.mcp_transport != "stdio":
         tools = {name: tool for name, tool in tools.items()
                  if tool.get("category") != "authentication"}
+    if not config.enable_display_item_tools:
+        tools = {name: tool for name, tool in tools.items()
+                 if name not in _DISPLAY_ITEM_TOOL_NAMES}
     return copy.deepcopy(tools)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,3 +13,7 @@ os.environ.setdefault("REALIZE_CLIENT_ID", "realize_mcp_ci_client")
 os.environ.setdefault("REALIZE_CLIENT_SECRET", "realize_mcp_ci_secret")
 os.environ.setdefault("MCP_TRANSPORT", "stdio")
 os.environ.setdefault("METRICS_ENABLED", "true")
+# Enable the display item tools by default in tests so existing display tests
+# pass without per-test setup. The dedicated flag tests override this via
+# monkeypatch.
+os.environ.setdefault("ENABLE_DISPLAY_ITEM_TOOLS", "true")

--- a/tests/test_create_campaign.py
+++ b/tests/test_create_campaign.py
@@ -60,6 +60,22 @@ class TestCreateCampaignHappyPath:
 
     @pytest.mark.asyncio
     @patch('realize.tools.campaign_handlers.client.post', new_callable=AsyncMock)
+    async def test_includes_optional_pricing_model(self, mock_post):
+        mock_post.return_value = {"id": "c-1"}
+
+        await handle_call_tool("create_campaign", _minimal_args(
+            pricing_model="VCPM",
+            bid_strategy="FIXED",
+            cpc=2.50,
+        ))
+
+        body = _post_body(mock_post)
+        assert body["pricing_model"] == "VCPM"
+        assert body["bid_strategy"] == "FIXED"
+        assert body["cpc"] == 2.50
+
+    @pytest.mark.asyncio
+    @patch('realize.tools.campaign_handlers.client.post', new_callable=AsyncMock)
     async def test_includes_optional_cpa_goal(self, mock_post):
         mock_post.return_value = {"id": "c-1"}
 
@@ -160,6 +176,17 @@ class TestCreateCampaignAnnotations:
         bs = create.inputSchema["properties"]["bid_strategy"]
 
         assert set(bs["enum"]) == {"SMART", "FIXED", "TARGET_CPA", "MAX_CONVERSIONS", "MAX_VALUE"}
+
+    @pytest.mark.asyncio
+    async def test_pricing_model_enum_in_schema(self):
+        from realize.realize_server import handle_list_tools
+
+        tools = await handle_list_tools()
+        create = next(t for t in tools if t.name == "create_campaign")
+        pm = create.inputSchema["properties"]["pricing_model"]
+
+        assert set(pm["enum"]) == {"CPC", "VCPM"}
+        assert "pricing_model" not in create.inputSchema["required"]
 
     @pytest.mark.asyncio
     async def test_spending_limit_model_enum_in_schema(self):

--- a/tests/test_create_display_item.py
+++ b/tests/test_create_display_item.py
@@ -1,0 +1,485 @@
+"""Tests for the create_display_item write tool."""
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from realize.realize_server import handle_call_tool
+from realize.tools.errors import ToolInputError
+
+
+_AD_TAG = '<script src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>'
+
+
+def _post_endpoint(mock_post):
+    args, kwargs = mock_post.call_args
+    return args[0] if args else kwargs.get("endpoint")
+
+
+def _post_body(mock_post):
+    _args, kwargs = mock_post.call_args
+    return kwargs.get("data")
+
+
+def _post_item(mock_post):
+    """Unwrap the single-item collection wrapper around the create payload."""
+    return _post_body(mock_post)["collection"][0]
+
+
+def _args(**overrides):
+    base = {
+        "account_id": "acme-inc",
+        "campaign_id": "49184816",
+        "url": "https://example.com/landing",
+        "ad_tag": _AD_TAG,
+        "dimensions": [{"width": 300, "height": 250}],
+        "creative_name": "Acme 300x250",
+    }
+    base.update(overrides)
+    return base
+
+
+class TestCreateDisplayItemHappyPath:
+    @pytest.mark.asyncio
+    @patch('realize.tools.item_display_handlers.client.post', new_callable=AsyncMock)
+    async def test_minimal_payload(self, mock_post):
+        mock_post.return_value = {"results": [{"id": "987654321", "status": "PENDING_APPROVAL"}]}
+
+        result = await handle_call_tool("create_display_item", _args())
+
+        assert _post_endpoint(mock_post) == "/acme-inc/campaigns/49184816/items/mass"
+        item = _post_item(mock_post)
+        assert item["url"] == "https://example.com/landing"
+        assert "creative_type" not in item
+        assert item["display_data"] == {
+            "ad_tag": _AD_TAG,
+            "dimensions": [{"width": 300, "height": 250}],
+        }
+        assert "display_ad_type" not in item["display_data"]
+        assert item["custom_data"] == {"creative_name": "Acme 300x250"}
+        assert "account_id" not in item
+        assert "campaign_id" not in item
+        assert "987654321" in result[0].text
+
+    @pytest.mark.asyncio
+    @patch('realize.tools.item_display_handlers.client.post', new_callable=AsyncMock)
+    async def test_alternate_dimension(self, mock_post):
+        mock_post.return_value = {"results": [{"id": "987654321"}]}
+
+        await handle_call_tool("create_display_item", _args(
+            dimensions=[{"width": 728, "height": 90}],
+        ))
+
+        item = _post_item(mock_post)
+        assert item["display_data"]["dimensions"] == [{"width": 728, "height": 90}]
+
+    @pytest.mark.asyncio
+    @patch('realize.tools.item_display_handlers.client.post', new_callable=AsyncMock)
+    async def test_branding_and_cta_dropped_for_display(self, mock_post):
+        """Display creatives don't support branding_text or cta — args silently dropped."""
+        mock_post.return_value = {"results": [{"id": "987654321"}]}
+
+        await handle_call_tool("create_display_item", _args(
+            branding_text="Acme",
+            cta={"cta_type": "LEARN_MORE"},
+        ))
+
+        item = _post_item(mock_post)
+        assert "branding_text" not in item
+        assert "cta" not in item
+
+    @pytest.mark.asyncio
+    @patch('realize.tools.item_display_handlers.client.post', new_callable=AsyncMock)
+    async def test_unknown_args_dropped(self, mock_post):
+        mock_post.return_value = {"results": [{"id": "987654321"}]}
+
+        await handle_call_tool("create_display_item", _args(extra_unknown="dropped"))
+
+        item = _post_item(mock_post)
+        assert "extra_unknown" not in item
+
+    @pytest.mark.asyncio
+    @patch('realize.tools.item_display_handlers.client.post', new_callable=AsyncMock)
+    async def test_dimension_extra_keys_stripped(self, mock_post):
+        mock_post.return_value = {"results": [{"id": "987654321"}]}
+
+        await handle_call_tool("create_display_item", _args(
+            dimensions=[{"width": 300, "height": 250, "rogue": "drop"}],
+        ))
+
+        item = _post_item(mock_post)
+        assert item["display_data"]["dimensions"] == [{"width": 300, "height": 250}]
+
+
+class TestCreateDisplayItemValidation:
+    @pytest.mark.asyncio
+    async def test_missing_account_id_raises(self):
+        with pytest.raises(ToolInputError, match="account_id is required"):
+            await handle_call_tool(
+                "create_display_item",
+                {
+                    "campaign_id": "49184816",
+                    "url": "https://example.com",
+                    "ad_tag": _AD_TAG,
+                    "dimensions": [{"width": 300, "height": 250}],
+                },
+            )
+
+    @pytest.mark.asyncio
+    async def test_numeric_account_id_rejected(self):
+        with pytest.raises(ToolInputError, match="search_accounts"):
+            await handle_call_tool("create_display_item", _args(account_id="12345"))
+
+    @pytest.mark.asyncio
+    async def test_missing_campaign_id_raises(self):
+        args = _args()
+        del args["campaign_id"]
+        with pytest.raises(ToolInputError, match="campaign_id is required"):
+            await handle_call_tool("create_display_item", args)
+
+    @pytest.mark.asyncio
+    async def test_missing_url_raises(self):
+        args = _args()
+        del args["url"]
+        with pytest.raises(ToolInputError, match="Missing required field.*url"):
+            await handle_call_tool("create_display_item", args)
+
+    @pytest.mark.asyncio
+    async def test_missing_ad_tag_raises(self):
+        args = _args()
+        del args["ad_tag"]
+        with pytest.raises(ToolInputError, match="Missing required field.*ad_tag"):
+            await handle_call_tool("create_display_item", args)
+
+    @pytest.mark.asyncio
+    async def test_missing_dimensions_raises(self):
+        args = _args()
+        del args["dimensions"]
+        with pytest.raises(ToolInputError, match="Missing required field.*dimensions"):
+            await handle_call_tool("create_display_item", args)
+
+    @pytest.mark.asyncio
+    async def test_ad_tag_must_be_string(self):
+        with pytest.raises(ToolInputError, match="ad_tag must be a string"):
+            await handle_call_tool("create_display_item", _args(ad_tag=12345))
+
+    @pytest.mark.asyncio
+    async def test_ad_tag_blank_rejected(self):
+        with pytest.raises(ToolInputError, match="Missing required field.*ad_tag"):
+            await handle_call_tool("create_display_item", _args(ad_tag=""))
+
+    @pytest.mark.asyncio
+    async def test_ad_tag_oversized_rejected(self):
+        oversized = "<script>" + ("a" * (16 * 1024)) + "</script>"
+        with pytest.raises(ToolInputError, match="ad_tag exceeds"):
+            await handle_call_tool("create_display_item", _args(ad_tag=oversized))
+
+    @pytest.mark.asyncio
+    async def test_dimensions_not_a_list_rejected(self):
+        with pytest.raises(ToolInputError, match="dimensions must be a non-empty array"):
+            await handle_call_tool("create_display_item", _args(
+                dimensions={"width": 300, "height": 250},
+            ))
+
+    @pytest.mark.asyncio
+    async def test_dimensions_empty_rejected(self):
+        with pytest.raises(ToolInputError, match="Missing required field.*dimensions"):
+            await handle_call_tool("create_display_item", _args(dimensions=[]))
+
+    @pytest.mark.asyncio
+    async def test_dimensions_multi_entry_rejected(self):
+        with pytest.raises(ToolInputError, match="exactly one"):
+            await handle_call_tool("create_display_item", _args(
+                dimensions=[
+                    {"width": 300, "height": 250},
+                    {"width": 728, "height": 90},
+                ],
+            ))
+
+    @pytest.mark.asyncio
+    async def test_dimension_missing_width_rejected(self):
+        with pytest.raises(ToolInputError, match=r"dimensions\[0\]\.width"):
+            await handle_call_tool("create_display_item", _args(
+                dimensions=[{"height": 250}],
+            ))
+
+    @pytest.mark.asyncio
+    async def test_dimension_zero_rejected(self):
+        with pytest.raises(ToolInputError, match=r"dimensions\[0\]\.height.*positive integer"):
+            await handle_call_tool("create_display_item", _args(
+                dimensions=[{"width": 300, "height": 0}],
+            ))
+
+    @pytest.mark.asyncio
+    async def test_dimension_string_rejected(self):
+        with pytest.raises(ToolInputError, match=r"dimensions\[0\]\.width.*positive integer"):
+            await handle_call_tool("create_display_item", _args(
+                dimensions=[{"width": "300", "height": 250}],
+            ))
+
+    @pytest.mark.asyncio
+    async def test_missing_creative_name_raises(self):
+        args = _args()
+        del args["creative_name"]
+        with pytest.raises(ToolInputError, match="Missing required field.*creative_name"):
+            await handle_call_tool("create_display_item", args)
+
+    @pytest.mark.asyncio
+    async def test_creative_name_blank_rejected(self):
+        with pytest.raises(ToolInputError, match="Missing required field.*creative_name"):
+            await handle_call_tool("create_display_item", _args(creative_name=""))
+
+    @pytest.mark.asyncio
+    async def test_creative_name_must_be_string(self):
+        with pytest.raises(ToolInputError, match="creative_name must be a string"):
+            await handle_call_tool("create_display_item", _args(creative_name=12345))
+
+    @pytest.mark.asyncio
+    async def test_creative_name_whitespace_rejected(self):
+        with pytest.raises(ToolInputError, match="creative_name must be a non-empty string"):
+            await handle_call_tool("create_display_item", _args(creative_name="   "))
+
+
+class TestCreateDisplayItemEncoding:
+    @pytest.mark.asyncio
+    @patch('realize.tools.item_display_handlers.client.post', new_callable=AsyncMock)
+    async def test_url_encodes_account_id_and_campaign_id(self, mock_post):
+        mock_post.return_value = {"results": [{"id": "987654321"}]}
+
+        await handle_call_tool("create_display_item", _args(
+            account_id="acme/evil", campaign_id="c/1",
+        ))
+
+        assert _post_endpoint(mock_post) == "/acme%2Fevil/campaigns/c%2F1/items/mass"
+
+
+class TestCreateDisplayItemAnnotations:
+    @pytest.mark.asyncio
+    async def test_has_destructive_annotations(self):
+        from realize.realize_server import handle_list_tools
+
+        tools = await handle_list_tools()
+        create = next(t for t in tools if t.name == "create_display_item")
+
+        assert create.annotations is not None
+        assert create.annotations.destructiveHint is True
+        assert create.annotations.idempotentHint is False
+        assert create.annotations.openWorldHint is True
+
+    @pytest.mark.asyncio
+    async def test_required_fields_in_schema(self):
+        from realize.realize_server import handle_list_tools
+
+        tools = await handle_list_tools()
+        create = next(t for t in tools if t.name == "create_display_item")
+
+        # ad_tag and asset_url are mutually-exclusive discriminators; the
+        # "exactly one of" rule is enforced by the handler, not the JSON Schema.
+        assert set(create.inputSchema["required"]) == {
+            "account_id", "campaign_id", "url", "creative_name",
+        }
+
+    @pytest.mark.asyncio
+    async def test_asset_url_in_create_schema(self):
+        from realize.realize_server import handle_list_tools
+
+        tools = await handle_list_tools()
+        create = next(t for t in tools if t.name == "create_display_item")
+
+        assert "asset_url" in create.inputSchema["properties"]
+        assert "ad_tag" in create.inputSchema["properties"]
+
+    @pytest.mark.asyncio
+    async def test_update_only_fields_not_in_create_schema(self):
+        """Update-only fields should not appear in the create surface."""
+        from realize.realize_server import handle_list_tools
+
+        tools = await handle_list_tools()
+        create = next(t for t in tools if t.name == "create_display_item")
+
+        for f in ("is_active", "verification_pixel", "viewability_tag"):
+            assert f not in create.inputSchema["properties"], \
+                f"create_display_item must not expose {f} (update-only field)"
+
+    @pytest.mark.asyncio
+    async def test_native_only_fields_absent(self):
+        """Native-specific scalars don't apply to display items."""
+        from realize.realize_server import handle_list_tools
+
+        tools = await handle_list_tools()
+        create = next(t for t in tools if t.name == "create_display_item")
+
+        for f in ("title", "description", "thumbnail_url"):
+            assert f not in create.inputSchema["properties"], \
+                f"create_display_item must not expose {f} (native-only field)"
+
+
+class TestCreateDisplayItemHostedAssetUrl:
+    """1P mode: asset_url posts display_data.hosted_display_data.asset_url; Realize ingests."""
+
+    def _hosted_args(self, **overrides):
+        base = {
+            "account_id": "acme-inc",
+            "campaign_id": "49184816",
+            "url": "https://example.com/landing",
+            "asset_url": "https://cdn.example.com/creatives/banner-300x250.png",
+            "creative_name": "Acme 300x250 — hosted image",
+        }
+        base.update(overrides)
+        return base
+
+    @pytest.mark.asyncio
+    @patch('realize.tools.item_display_handlers.client.post', new_callable=AsyncMock)
+    async def test_hosted_image_minimal(self, mock_post):
+        mock_post.return_value = {"results": [{"id": "987654321", "display_data": {"display_ad_type": "HOSTED_IMAGE"}}]}
+
+        await handle_call_tool("create_display_item", self._hosted_args())
+
+        item = _post_item(mock_post)
+        assert item["url"] == "https://example.com/landing"
+        assert item["display_data"] == {
+            "hosted_display_data": {
+                "asset_url": "https://cdn.example.com/creatives/banner-300x250.png",
+            },
+        }
+        assert "ad_tag" not in item["display_data"]
+        assert "dimensions" not in item["display_data"]
+        # Subtype is detected by Realize from the URL's file extension (Content-Type fallback); never set client-side.
+        assert "display_ad_type" not in item["display_data"]
+        assert "display_ad_type" not in item["display_data"]["hosted_display_data"]
+        assert item["custom_data"] == {"creative_name": "Acme 300x250 — hosted image"}
+
+    @pytest.mark.asyncio
+    @patch('realize.tools.item_display_handlers.client.post', new_callable=AsyncMock)
+    async def test_hosted_video_url_same_field(self, mock_post):
+        """HOSTED_VIDEO uses the same asset_url field — subtype detected server-side from the URL's file extension (Content-Type fallback)."""
+        mock_post.return_value = {"results": [{"id": "987654321"}]}
+
+        await handle_call_tool("create_display_item", self._hosted_args(
+            asset_url="https://cdn.example.com/creatives/clip.mp4",
+        ))
+
+        item = _post_item(mock_post)
+        assert item["display_data"]["hosted_display_data"]["asset_url"] == \
+            "https://cdn.example.com/creatives/clip.mp4"
+
+    @pytest.mark.asyncio
+    @patch('realize.tools.item_display_handlers.client.post', new_callable=AsyncMock)
+    async def test_hosted_html_zip_url_same_field(self, mock_post):
+        mock_post.return_value = {"results": [{"id": "987654321"}]}
+
+        await handle_call_tool("create_display_item", self._hosted_args(
+            asset_url="https://cdn.example.com/creatives/bundle.zip",
+        ))
+
+        item = _post_item(mock_post)
+        assert item["display_data"]["hosted_display_data"]["asset_url"] == \
+            "https://cdn.example.com/creatives/bundle.zip"
+
+
+class TestCreateDisplayItemModeMutex:
+    """Discriminator mutex: exactly one of ad_tag or asset_url is required on create."""
+
+    @pytest.mark.asyncio
+    async def test_neither_discriminator_provided_rejected(self):
+        with pytest.raises(ToolInputError, match="Missing required field.*ad_tag or asset_url"):
+            await handle_call_tool("create_display_item", {
+                "account_id": "acme-inc",
+                "campaign_id": "49184816",
+                "url": "https://example.com/landing",
+                "creative_name": "Acme 300x250",
+            })
+
+    @pytest.mark.asyncio
+    async def test_both_discriminators_provided_rejected(self):
+        with pytest.raises(ToolInputError, match="mutually exclusive"):
+            await handle_call_tool("create_display_item", _args(
+                asset_url="https://cdn.example.com/banner.png",
+            ))
+
+    @pytest.mark.asyncio
+    async def test_asset_url_with_dimensions_rejected(self):
+        """Server populates dimensions from the asset; sending them is rejected."""
+        with pytest.raises(ToolInputError, match="dimensions is not accepted with asset_url"):
+            await handle_call_tool("create_display_item", {
+                "account_id": "acme-inc",
+                "campaign_id": "49184816",
+                "url": "https://example.com/landing",
+                "asset_url": "https://cdn.example.com/banner.png",
+                "dimensions": [{"width": 300, "height": 250}],
+                "creative_name": "Acme",
+            })
+
+    @pytest.mark.asyncio
+    async def test_asset_url_http_rejected(self):
+        with pytest.raises(ToolInputError, match="asset_url must be an https URL"):
+            await handle_call_tool("create_display_item", {
+                "account_id": "acme-inc",
+                "campaign_id": "49184816",
+                "url": "https://example.com/landing",
+                "asset_url": "http://cdn.example.com/banner.png",
+                "creative_name": "Acme",
+            })
+
+    @pytest.mark.asyncio
+    async def test_asset_url_not_string_rejected(self):
+        with pytest.raises(ToolInputError, match="asset_url must be a string"):
+            await handle_call_tool("create_display_item", {
+                "account_id": "acme-inc",
+                "campaign_id": "49184816",
+                "url": "https://example.com/landing",
+                "asset_url": 12345,
+                "creative_name": "Acme",
+            })
+
+    @pytest.mark.asyncio
+    async def test_asset_url_blank_rejected(self):
+        # bool("") is False → falls through to the create-time missing check.
+        with pytest.raises(ToolInputError, match="Missing required field.*ad_tag or asset_url"):
+            await handle_call_tool("create_display_item", {
+                "account_id": "acme-inc",
+                "campaign_id": "49184816",
+                "url": "https://example.com/landing",
+                "asset_url": "",
+                "creative_name": "Acme",
+            })
+
+
+class TestCreateDisplayItemUpdateOnlyFieldsStripped:
+    """Even if a caller passes update-only fields, the create handler must drop them."""
+
+    @pytest.mark.asyncio
+    @patch('realize.tools.item_display_handlers.client.post', new_callable=AsyncMock)
+    async def test_is_active_dropped_on_create(self, mock_post):
+        mock_post.return_value = {"results": [{"id": "987654321"}]}
+
+        await handle_call_tool("create_display_item", _args(is_active=False))
+
+        item = _post_item(mock_post)
+        assert "is_active" not in item
+
+    @pytest.mark.asyncio
+    @patch('realize.tools.item_display_handlers.client.post', new_callable=AsyncMock)
+    async def test_verification_pixel_dropped_on_create(self, mock_post):
+        mock_post.return_value = {"results": [{"id": "987654321"}]}
+
+        await handle_call_tool("create_display_item", _args(
+            verification_pixel={
+                "verification_pixel_items": [
+                    {"url": "https://x.example/c", "verification_pixel_type": "CLICK"},
+                ],
+            },
+        ))
+
+        item = _post_item(mock_post)
+        assert "verification_pixel" not in item
+
+    @pytest.mark.asyncio
+    @patch('realize.tools.item_display_handlers.client.post', new_callable=AsyncMock)
+    async def test_viewability_tag_dropped_on_create(self, mock_post):
+        mock_post.return_value = {"results": [{"id": "987654321"}]}
+
+        await handle_call_tool("create_display_item", _args(
+            viewability_tag={"values": [{"tag": "<script/>", "type": "IAS"}]},
+        ))
+
+        item = _post_item(mock_post)
+        assert "viewability_tag" not in item

--- a/tests/test_create_native_item.py
+++ b/tests/test_create_native_item.py
@@ -36,7 +36,7 @@ def _args(**overrides):
 
 class TestCreateCampaignItemHappyPath:
     @pytest.mark.asyncio
-    @patch('realize.tools.item_handlers.client.post', new_callable=AsyncMock)
+    @patch('realize.tools.item_native_handlers.client.post', new_callable=AsyncMock)
     async def test_minimal_required_fields(self, mock_post):
         mock_post.return_value = {"results": [{"id": "987654321", "status": "PENDING_APPROVAL"}]}
 
@@ -56,7 +56,7 @@ class TestCreateCampaignItemHappyPath:
         assert "987654321" in result[0].text
 
     @pytest.mark.asyncio
-    @patch('realize.tools.item_handlers.client.post', new_callable=AsyncMock)
+    @patch('realize.tools.item_native_handlers.client.post', new_callable=AsyncMock)
     async def test_full_create_payload(self, mock_post):
         mock_post.return_value = {"results": [{"id": "987654321"}]}
 
@@ -78,7 +78,7 @@ class TestCreateCampaignItemHappyPath:
         assert "is_active" not in item
 
     @pytest.mark.asyncio
-    @patch('realize.tools.item_handlers.client.post', new_callable=AsyncMock)
+    @patch('realize.tools.item_native_handlers.client.post', new_callable=AsyncMock)
     async def test_unknown_args_dropped(self, mock_post):
         mock_post.return_value = {"results": [{"id": "987654321"}]}
 
@@ -152,10 +152,41 @@ class TestCreateCampaignItemValidation:
         with pytest.raises(ToolInputError, match="cta.cta_type"):
             await handle_call_tool("create_native_item", _args(cta={"cta_type": ""}))
 
+    @pytest.mark.asyncio
+    @patch('realize.tools.item_native_handlers.client.post', new_callable=AsyncMock)
+    async def test_creative_name_passthrough(self, mock_post):
+        mock_post.return_value = {"results": [{"id": "987654321"}]}
+
+        await handle_call_tool("create_native_item", _args(creative_name="Spring Sale Native"))
+
+        item = _post_item(mock_post)
+        assert item["custom_data"] == {"creative_name": "Spring Sale Native"}
+
+    @pytest.mark.asyncio
+    @patch('realize.tools.item_native_handlers.client.post', new_callable=AsyncMock)
+    async def test_creative_name_omitted_no_custom_data(self, mock_post):
+        """Native is optional — no custom_data block when caller omits creative_name."""
+        mock_post.return_value = {"results": [{"id": "987654321"}]}
+
+        await handle_call_tool("create_native_item", _args())
+
+        item = _post_item(mock_post)
+        assert "custom_data" not in item
+
+    @pytest.mark.asyncio
+    async def test_creative_name_blank_rejected(self):
+        with pytest.raises(ToolInputError, match="creative_name must be a non-empty string"):
+            await handle_call_tool("create_native_item", _args(creative_name=""))
+
+    @pytest.mark.asyncio
+    async def test_creative_name_invalid_type_rejected(self):
+        with pytest.raises(ToolInputError, match="creative_name must be a string"):
+            await handle_call_tool("create_native_item", _args(creative_name=123))
+
 
 class TestCreateCampaignItemEncoding:
     @pytest.mark.asyncio
-    @patch('realize.tools.item_handlers.client.post', new_callable=AsyncMock)
+    @patch('realize.tools.item_native_handlers.client.post', new_callable=AsyncMock)
     async def test_url_encodes_account_id_and_campaign_id(self, mock_post):
         mock_post.return_value = {"results": [{"id": "987654321"}]}
 
@@ -219,7 +250,7 @@ class TestCreateCampaignItemUpdateOnlyFieldsStripped:
     """Even if a caller passes update-only fields, the create handler must drop them."""
 
     @pytest.mark.asyncio
-    @patch('realize.tools.item_handlers.client.post', new_callable=AsyncMock)
+    @patch('realize.tools.item_native_handlers.client.post', new_callable=AsyncMock)
     async def test_start_end_date_dropped_on_create(self, mock_post):
         mock_post.return_value = {"results": [{"id": "987654321"}]}
 
@@ -233,7 +264,7 @@ class TestCreateCampaignItemUpdateOnlyFieldsStripped:
         assert "end_date" not in item
 
     @pytest.mark.asyncio
-    @patch('realize.tools.item_handlers.client.post', new_callable=AsyncMock)
+    @patch('realize.tools.item_native_handlers.client.post', new_callable=AsyncMock)
     async def test_activity_schedule_dropped_on_create(self, mock_post):
         mock_post.return_value = {"results": [{"id": "987654321"}]}
 
@@ -245,7 +276,7 @@ class TestCreateCampaignItemUpdateOnlyFieldsStripped:
         assert "activity_schedule" not in item
 
     @pytest.mark.asyncio
-    @patch('realize.tools.item_handlers.client.post', new_callable=AsyncMock)
+    @patch('realize.tools.item_native_handlers.client.post', new_callable=AsyncMock)
     async def test_verification_pixel_dropped_on_create(self, mock_post):
         mock_post.return_value = {"results": [{"id": "987654321"}]}
 
@@ -257,7 +288,7 @@ class TestCreateCampaignItemUpdateOnlyFieldsStripped:
         assert "verification_pixel" not in item
 
     @pytest.mark.asyncio
-    @patch('realize.tools.item_handlers.client.post', new_callable=AsyncMock)
+    @patch('realize.tools.item_native_handlers.client.post', new_callable=AsyncMock)
     async def test_viewability_tag_dropped_on_create(self, mock_post):
         mock_post.return_value = {"results": [{"id": "987654321"}]}
 

--- a/tests/test_display_item_flag.py
+++ b/tests/test_display_item_flag.py
@@ -1,0 +1,92 @@
+"""Tests for the ENABLE_DISPLAY_ITEM_TOOLS feature flag."""
+import pytest
+
+from realize.realize_server import handle_call_tool
+from realize.tools.registry import TOOL_REGISTRY, get_all_tools
+
+
+_DISPLAY_TOOLS = {"create_display_item", "update_display_item"}
+
+
+@pytest.fixture
+def _stub_config(monkeypatch):
+    """Override only the flag on the real config; keep other attrs intact."""
+    from realize import config as config_module
+
+    monkeypatch.setattr(config_module.config, "enable_display_item_tools", False)
+    yield config_module.config
+
+
+class TestDisplayItemFlagDefault:
+    def test_display_tools_registered_in_static_registry(self):
+        """Registry itself always contains the tools — gating happens in get_all_tools()."""
+        assert _DISPLAY_TOOLS.issubset(TOOL_REGISTRY.keys())
+
+    def test_display_tools_hidden_by_default(self, _stub_config):
+        _stub_config.enable_display_item_tools = False
+        tools = get_all_tools()
+        assert _DISPLAY_TOOLS.isdisjoint(tools.keys())
+
+    def test_native_item_tools_still_present_when_display_off(self, _stub_config):
+        _stub_config.enable_display_item_tools = False
+        tools = get_all_tools()
+        assert "create_native_item" in tools
+        assert "update_native_item" in tools
+        assert "list_items" in tools
+        assert "get_item" in tools
+
+    def test_display_tools_shown_when_flag_true(self, _stub_config):
+        _stub_config.enable_display_item_tools = True
+        tools = get_all_tools()
+        assert _DISPLAY_TOOLS.issubset(tools.keys())
+
+
+class TestDisplayItemFlagDispatcher:
+    @pytest.mark.asyncio
+    async def test_create_display_item_rejected_when_flag_off(self, _stub_config):
+        _stub_config.enable_display_item_tools = False
+        with pytest.raises(ValueError, match="Unknown tool: create_display_item"):
+            await handle_call_tool("create_display_item", {
+                "account_id": "acme-inc",
+                "campaign_id": "49184816",
+                "url": "https://example.com/landing",
+                "ad_tag": "<script/>",
+                "dimensions": [{"width": 300, "height": 250}],
+                "creative_name": "Acme 300x250",
+            })
+
+    @pytest.mark.asyncio
+    async def test_update_display_item_rejected_when_flag_off(self, _stub_config):
+        _stub_config.enable_display_item_tools = False
+        with pytest.raises(ValueError, match="Unknown tool: update_display_item"):
+            await handle_call_tool("update_display_item", {
+                "account_id": "acme-inc",
+                "campaign_id": "49184816",
+                "item_id": "987654321",
+                "is_active": False,
+            })
+
+
+class TestDisplayItemFlagConfigParsing:
+    def test_env_var_default_false(self, monkeypatch):
+        from realize.config import Config
+
+        # conftest defaults the env var to "true" for the test session; clear it
+        # to verify the model's own default is False.
+        monkeypatch.delenv("ENABLE_DISPLAY_ITEM_TOOLS", raising=False)
+        cfg = Config(realize_client_id="x", realize_client_secret="y", _env_file=None)
+        assert cfg.enable_display_item_tools is False
+
+    @pytest.mark.parametrize("env_value,expected", [
+        ("true", True),
+        ("True", True),
+        ("1", True),
+        ("false", False),
+        ("0", False),
+    ])
+    def test_env_var_parsed(self, monkeypatch, env_value, expected):
+        from realize.config import Config
+
+        monkeypatch.setenv("ENABLE_DISPLAY_ITEM_TOOLS", env_value)
+        cfg = Config(realize_client_id="x", realize_client_secret="y", _env_file=None)
+        assert cfg.enable_display_item_tools is expected

--- a/tests/test_path_encoding.py
+++ b/tests/test_path_encoding.py
@@ -70,7 +70,7 @@ class TestCampaignHandlersEncoding:
         assert _get_endpoint_arg(mock_get) == "/acct.1/campaigns/123%3Fx%3D1"
 
     @pytest.mark.asyncio
-    @patch('realize.tools.item_handlers.client.get', new_callable=AsyncMock)
+    @patch('realize.tools.item_read_handlers.client.get', new_callable=AsyncMock)
     async def test_list_items_encodes_both_ids(self, mock_get):
         mock_get.return_value = {"results": []}
 
@@ -82,7 +82,7 @@ class TestCampaignHandlersEncoding:
         assert _get_endpoint_arg(mock_get) == "/a%2Fb/campaigns/c%23d/items"
 
     @pytest.mark.asyncio
-    @patch('realize.tools.item_handlers.client.get', new_callable=AsyncMock)
+    @patch('realize.tools.item_read_handlers.client.get', new_callable=AsyncMock)
     async def test_get_item_encodes_all_three_ids(self, mock_get):
         mock_get.return_value = {"id": "x"}
 

--- a/tests/test_tool_registration.py
+++ b/tests/test_tool_registration.py
@@ -77,7 +77,9 @@ class TestToolRegistryEdgeCases:
             'auth_handlers.',
             'account_handlers.',
             'campaign_handlers.',
-            'item_handlers.',
+            'item_read_handlers.',
+            'item_native_handlers.',
+            'item_display_handlers.',
             'report_handlers.',
             'resources.',
             'discovery_handlers.',
@@ -186,7 +188,9 @@ class TestToolHandlerImports:
             'realize.tools.auth_handlers',
             'realize.tools.account_handlers',
             'realize.tools.campaign_handlers',
-            'realize.tools.item_handlers',
+            'realize.tools.item_read_handlers',
+            'realize.tools.item_native_handlers',
+            'realize.tools.item_display_handlers',
             'realize.tools.report_handlers'
         ]
         
@@ -306,7 +310,7 @@ class TestItemAndDiscoveryAdditions:
         assert "create_native_item" in TOOL_REGISTRY
         entry = TOOL_REGISTRY["create_native_item"]
         assert entry["category"] == "items"
-        assert entry["handler"] == "item_handlers.create_native_item"
+        assert entry["handler"] == "item_native_handlers.create_native_item"
         assert entry["annotations"]["destructiveHint"] is True
         assert entry["annotations"]["idempotentHint"] is False
 
@@ -314,9 +318,34 @@ class TestItemAndDiscoveryAdditions:
         assert "update_native_item" in TOOL_REGISTRY
         entry = TOOL_REGISTRY["update_native_item"]
         assert entry["category"] == "items"
-        assert entry["handler"] == "item_handlers.update_native_item"
+        assert entry["handler"] == "item_native_handlers.update_native_item"
         assert entry["annotations"]["destructiveHint"] is True
         assert entry["annotations"]["idempotentHint"] is True
+
+    def test_create_display_item_registered(self):
+        assert "create_display_item" in TOOL_REGISTRY
+        entry = TOOL_REGISTRY["create_display_item"]
+        assert entry["category"] == "items"
+        assert entry["handler"] == "item_display_handlers.create_display_item"
+        assert entry["annotations"]["destructiveHint"] is True
+        assert entry["annotations"]["idempotentHint"] is False
+        # ad_tag and asset_url are mutually-exclusive discriminators enforced
+        # by the handler, not the JSON Schema. dimensions is required only
+        # when ad_tag is sent.
+        assert set(entry["schema"]["required"]) == {
+            "account_id", "campaign_id", "url", "creative_name"
+        }
+
+    def test_update_display_item_registered(self):
+        assert "update_display_item" in TOOL_REGISTRY
+        entry = TOOL_REGISTRY["update_display_item"]
+        assert entry["category"] == "items"
+        assert entry["handler"] == "item_display_handlers.update_display_item"
+        assert entry["annotations"]["destructiveHint"] is True
+        assert entry["annotations"]["idempotentHint"] is True
+        assert set(entry["schema"]["required"]) == {
+            "account_id", "campaign_id", "item_id"
+        }
 
     def test_list_cta_types_registered(self):
         assert "list_cta_types" in TOOL_REGISTRY
@@ -325,8 +354,8 @@ class TestItemAndDiscoveryAdditions:
         assert entry["handler"] == "resources.list_cta_types"
 
     def test_read_item_tools_repointed(self):
-        assert TOOL_REGISTRY["list_items"]["handler"] == "item_handlers.list_items"
-        assert TOOL_REGISTRY["get_item"]["handler"] == "item_handlers.get_item"
+        assert TOOL_REGISTRY["list_items"]["handler"] == "item_read_handlers.list_items"
+        assert TOOL_REGISTRY["get_item"]["handler"] == "item_read_handlers.get_item"
 
 
 if __name__ == "__main__":

--- a/tests/test_update_campaign.py
+++ b/tests/test_update_campaign.py
@@ -103,6 +103,7 @@ class TestUpdateCampaignWireMapping:
         ("spending_limit", 5000, {}),
         ("daily_cap", 50, {}),
         ("cpc", 0.25, {}),
+        ("pricing_model", "VCPM", {}),
         ("bid_strategy", "MAX_CONVERSIONS", {}),
         ("cpa_goal", 15, {}),
         ("start_date", "2026-05-01", {}),
@@ -240,7 +241,16 @@ class TestUpdateCampaignSchema:
         assert update.inputSchema["required"] == ["account_id", "campaign_id"]
 
     @pytest.mark.asyncio
-    async def test_all_16_fields_present_as_optional_properties(self):
+    async def test_pricing_model_enum(self):
+        from realize.realize_server import handle_list_tools
+
+        tools = await handle_list_tools()
+        update = next(t for t in tools if t.name == "update_campaign")
+        pm = update.inputSchema["properties"]["pricing_model"]
+        assert set(pm["enum"]) == {"CPC", "VCPM"}
+
+    @pytest.mark.asyncio
+    async def test_all_17_fields_present_as_optional_properties(self):
         from realize.realize_server import handle_list_tools
 
         tools = await handle_list_tools()
@@ -250,7 +260,7 @@ class TestUpdateCampaignSchema:
 
         expected_fields = {
             "name", "marketing_objective", "branding_text", "spending_limit_model",
-            "spending_limit", "daily_cap", "cpc", "bid_strategy", "cpa_goal",
+            "spending_limit", "daily_cap", "cpc", "pricing_model", "bid_strategy", "cpa_goal",
             "start_date", "end_date", "tracking_code", "cpc_cap",
             "daily_ad_delivery_model", "traffic_allocation_mode", "is_active",
         }

--- a/tests/test_update_display_item.py
+++ b/tests/test_update_display_item.py
@@ -1,0 +1,417 @@
+"""Tests for the update_display_item write tool."""
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from realize.realize_server import handle_call_tool
+from realize.tools.errors import ToolInputError
+
+
+_AD_TAG = '<script src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>'
+
+
+def _post_endpoint(mock_post):
+    args, kwargs = mock_post.call_args
+    return args[0] if args else kwargs.get("endpoint")
+
+
+def _post_body(mock_post):
+    _args, kwargs = mock_post.call_args
+    return kwargs.get("data")
+
+
+def _args(**overrides):
+    base = {
+        "account_id": "acme-inc",
+        "campaign_id": "49184816",
+        "item_id": "987654321",
+        "is_active": False,
+    }
+    base.update(overrides)
+    return base
+
+
+class TestUpdateDisplayItemBaseValidation:
+    @pytest.mark.asyncio
+    async def test_missing_account_id_raises(self):
+        with pytest.raises(ToolInputError, match="account_id is required"):
+            await handle_call_tool(
+                "update_display_item",
+                {"campaign_id": "49184816", "item_id": "987654321", "is_active": False},
+            )
+
+    @pytest.mark.asyncio
+    async def test_numeric_account_id_rejected(self):
+        with pytest.raises(ToolInputError, match="search_accounts"):
+            await handle_call_tool("update_display_item", _args(account_id="12345"))
+
+    @pytest.mark.asyncio
+    async def test_missing_campaign_id_raises(self):
+        args = _args()
+        del args["campaign_id"]
+        with pytest.raises(ToolInputError, match="campaign_id is required"):
+            await handle_call_tool("update_display_item", args)
+
+    @pytest.mark.asyncio
+    async def test_missing_item_id_raises(self):
+        args = _args()
+        del args["item_id"]
+        with pytest.raises(ToolInputError, match="item_id is required"):
+            await handle_call_tool("update_display_item", args)
+
+    @pytest.mark.asyncio
+    async def test_no_updatable_fields_rejected(self):
+        with pytest.raises(ToolInputError, match="at least one updatable field"):
+            await handle_call_tool(
+                "update_display_item",
+                {"account_id": "acme-inc", "campaign_id": "49184816", "item_id": "987654321"},
+            )
+
+
+class TestUpdateDisplayItemWireMapping:
+    @pytest.mark.asyncio
+    @patch('realize.tools.item_display_handlers.client.post', new_callable=AsyncMock)
+    async def test_posts_to_item_endpoint(self, mock_post):
+        mock_post.return_value = {"id": "987654321"}
+        await handle_call_tool("update_display_item", _args())
+        assert _post_endpoint(mock_post) == "/acme-inc/campaigns/49184816/items/987654321"
+
+    @pytest.mark.asyncio
+    @patch('realize.tools.item_display_handlers.client.post', new_callable=AsyncMock)
+    async def test_url_encodes_path_segments(self, mock_post):
+        mock_post.return_value = {"id": "987654321"}
+        await handle_call_tool("update_display_item", _args(
+            account_id="acme/evil",
+            campaign_id="c/1",
+            item_id="i/1",
+        ))
+        assert _post_endpoint(mock_post) == "/acme%2Fevil/campaigns/c%2F1/items/i%2F1"
+
+    @pytest.mark.asyncio
+    @patch('realize.tools.item_display_handlers.client.post', new_callable=AsyncMock)
+    async def test_path_ids_not_in_body(self, mock_post):
+        mock_post.return_value = {"id": "987654321"}
+        await handle_call_tool("update_display_item", _args())
+        body = _post_body(mock_post)
+        assert "account_id" not in body
+        assert "campaign_id" not in body
+        assert "item_id" not in body
+
+    @pytest.mark.asyncio
+    @patch('realize.tools.item_display_handlers.client.post', new_callable=AsyncMock)
+    async def test_is_active_only(self, mock_post):
+        mock_post.return_value = {"id": "987654321"}
+        await handle_call_tool("update_display_item", _args())
+        assert _post_body(mock_post) == {"is_active": False}
+
+    @pytest.mark.asyncio
+    @patch('realize.tools.item_display_handlers.client.post', new_callable=AsyncMock)
+    async def test_creative_type_and_display_ad_type_never_sent(self, mock_post):
+        """update_display_item must never set creative_type or display_data.display_ad_type."""
+        mock_post.return_value = {"id": "987654321"}
+        await handle_call_tool("update_display_item", _args(ad_tag=_AD_TAG))
+        body = _post_body(mock_post)
+        assert "creative_type" not in body
+        assert "display_ad_type" not in body.get("display_data", {})
+
+
+class TestUpdateDisplayItemDisplayDataPartialMerge:
+    @pytest.mark.asyncio
+    @patch('realize.tools.item_display_handlers.client.post', new_callable=AsyncMock)
+    async def test_ad_tag_only(self, mock_post):
+        """Sending ad_tag without dimensions emits display_data with just ad_tag."""
+        mock_post.return_value = {"id": "987654321"}
+        await handle_call_tool(
+            "update_display_item",
+            {
+                "account_id": "acme-inc",
+                "campaign_id": "49184816",
+                "item_id": "987654321",
+                "ad_tag": _AD_TAG,
+            },
+        )
+        body = _post_body(mock_post)
+        assert body == {"display_data": {"ad_tag": _AD_TAG}}
+
+    @pytest.mark.asyncio
+    @patch('realize.tools.item_display_handlers.client.post', new_callable=AsyncMock)
+    async def test_dimensions_only(self, mock_post):
+        """Sending dimensions without ad_tag emits display_data with just dimensions."""
+        mock_post.return_value = {"id": "987654321"}
+        await handle_call_tool(
+            "update_display_item",
+            {
+                "account_id": "acme-inc",
+                "campaign_id": "49184816",
+                "item_id": "987654321",
+                "dimensions": [{"width": 300, "height": 250}],
+            },
+        )
+        body = _post_body(mock_post)
+        assert body == {"display_data": {"dimensions": [{"width": 300, "height": 250}]}}
+
+    @pytest.mark.asyncio
+    @patch('realize.tools.item_display_handlers.client.post', new_callable=AsyncMock)
+    async def test_ad_tag_and_dimensions_together(self, mock_post):
+        mock_post.return_value = {"id": "987654321"}
+        await handle_call_tool("update_display_item", _args(
+            ad_tag=_AD_TAG,
+            dimensions=[{"width": 728, "height": 90}],
+        ))
+        body = _post_body(mock_post)
+        assert body["display_data"] == {
+            "ad_tag": _AD_TAG,
+            "dimensions": [{"width": 728, "height": 90}],
+        }
+
+    @pytest.mark.asyncio
+    async def test_dimensions_multi_entry_rejected(self):
+        with pytest.raises(ToolInputError, match="exactly one"):
+            await handle_call_tool("update_display_item", _args(
+                dimensions=[
+                    {"width": 300, "height": 250},
+                    {"width": 728, "height": 90},
+                ],
+            ))
+
+    @pytest.mark.asyncio
+    async def test_ad_tag_invalid_type_rejected(self):
+        with pytest.raises(ToolInputError, match="ad_tag must be a string"):
+            await handle_call_tool("update_display_item", _args(ad_tag=123))
+
+    @pytest.mark.asyncio
+    async def test_dimension_invalid_rejected(self):
+        with pytest.raises(ToolInputError, match=r"dimensions\[0\]\.width"):
+            await handle_call_tool("update_display_item", _args(
+                dimensions=[{"height": 250}],
+            ))
+
+    @pytest.mark.parametrize("field,value", [
+        ("url", "https://example.com/new"),
+        ("is_active", True),
+    ])
+    @pytest.mark.asyncio
+    @patch('realize.tools.item_display_handlers.client.post', new_callable=AsyncMock)
+    async def test_scalar_field_pass_through(self, mock_post, field, value):
+        mock_post.return_value = {"id": "987654321"}
+        args = {"account_id": "acme-inc", "campaign_id": "49184816", "item_id": "987654321", field: value}
+        await handle_call_tool("update_display_item", args)
+        assert _post_body(mock_post) == {field: value}
+
+    @pytest.mark.asyncio
+    @patch('realize.tools.item_display_handlers.client.post', new_callable=AsyncMock)
+    async def test_branding_and_cta_dropped_for_display(self, mock_post):
+        """Display creatives don't support branding_text or cta — args silently dropped."""
+        mock_post.return_value = {"id": "987654321"}
+        await handle_call_tool("update_display_item", _args(
+            branding_text="Acme",
+            cta={"cta_type": "LEARN_MORE"},
+        ))
+        body = _post_body(mock_post)
+        assert "branding_text" not in body
+        assert "cta" not in body
+
+    @pytest.mark.asyncio
+    @patch('realize.tools.item_display_handlers.client.post', new_callable=AsyncMock)
+    async def test_creative_name_only(self, mock_post):
+        """Sending only creative_name emits a custom_data block, no display_data."""
+        mock_post.return_value = {"id": "987654321"}
+        await handle_call_tool(
+            "update_display_item",
+            {
+                "account_id": "acme-inc",
+                "campaign_id": "49184816",
+                "item_id": "987654321",
+                "creative_name": "Acme 300x250 — renamed",
+            },
+        )
+        body = _post_body(mock_post)
+        assert body == {"custom_data": {"creative_name": "Acme 300x250 — renamed"}}
+
+    @pytest.mark.asyncio
+    async def test_creative_name_blank_rejected(self):
+        with pytest.raises(ToolInputError, match="creative_name must be a non-empty string"):
+            await handle_call_tool("update_display_item", _args(creative_name=""))
+
+    @pytest.mark.asyncio
+    async def test_creative_name_invalid_type_rejected(self):
+        with pytest.raises(ToolInputError, match="creative_name must be a string"):
+            await handle_call_tool("update_display_item", _args(creative_name=42))
+
+
+class TestUpdateDisplayItemHostedAssetUrl:
+    """1P mode on update: asset_url replaces the hosted asset; subtype is re-detected."""
+
+    @pytest.mark.asyncio
+    @patch('realize.tools.item_display_handlers.client.post', new_callable=AsyncMock)
+    async def test_asset_url_only(self, mock_post):
+        mock_post.return_value = {"id": "987654321"}
+        await handle_call_tool(
+            "update_display_item",
+            {
+                "account_id": "acme-inc",
+                "campaign_id": "49184816",
+                "item_id": "987654321",
+                "asset_url": "https://cdn.example.com/creatives/banner-v2.png",
+            },
+        )
+        body = _post_body(mock_post)
+        assert body == {
+            "display_data": {
+                "hosted_display_data": {
+                    "asset_url": "https://cdn.example.com/creatives/banner-v2.png",
+                },
+            },
+        }
+
+    @pytest.mark.asyncio
+    async def test_asset_url_with_ad_tag_rejected(self):
+        with pytest.raises(ToolInputError, match="mutually exclusive"):
+            await handle_call_tool("update_display_item", _args(
+                ad_tag=_AD_TAG,
+                asset_url="https://cdn.example.com/banner.png",
+            ))
+
+    @pytest.mark.asyncio
+    async def test_asset_url_with_dimensions_rejected(self):
+        with pytest.raises(ToolInputError, match="dimensions is not accepted with asset_url"):
+            await handle_call_tool("update_display_item", _args(
+                asset_url="https://cdn.example.com/banner.png",
+                dimensions=[{"width": 300, "height": 250}],
+            ))
+
+    @pytest.mark.asyncio
+    async def test_asset_url_http_rejected(self):
+        with pytest.raises(ToolInputError, match="asset_url must be an https URL"):
+            await handle_call_tool("update_display_item", _args(
+                asset_url="http://cdn.example.com/banner.png",
+            ))
+
+
+class TestUpdateDisplayItemNested:
+    @pytest.mark.asyncio
+    @patch('realize.tools.item_display_handlers.client.post', new_callable=AsyncMock)
+    async def test_verification_pixel_full_replace(self, mock_post):
+        mock_post.return_value = {"id": "987654321"}
+        await handle_call_tool("update_display_item", _args(
+            verification_pixel={
+                "verification_pixel_items": [
+                    {"url": "https://verify.example.com/c", "verification_pixel_type": "CLICK"},
+                ],
+            },
+        ))
+        body = _post_body(mock_post)
+        assert body["verification_pixel"] == {
+            "verification_pixel_items": [
+                {"url": "https://verify.example.com/c", "verification_pixel_type": "CLICK"},
+            ],
+        }
+
+    @pytest.mark.asyncio
+    @patch('realize.tools.item_display_handlers.client.post', new_callable=AsyncMock)
+    async def test_verification_pixel_empty_clears(self, mock_post):
+        mock_post.return_value = {"id": "987654321"}
+        await handle_call_tool("update_display_item", _args(
+            verification_pixel={"verification_pixel_items": []},
+        ))
+        body = _post_body(mock_post)
+        assert body["verification_pixel"] == {"verification_pixel_items": []}
+
+    @pytest.mark.asyncio
+    @patch('realize.tools.item_display_handlers.client.post', new_callable=AsyncMock)
+    async def test_viewability_tag_full_replace(self, mock_post):
+        mock_post.return_value = {"id": "987654321"}
+        await handle_call_tool("update_display_item", _args(
+            viewability_tag={
+                "values": [
+                    {"tag": "<script>1</script>", "type": "IAS"},
+                ],
+            },
+        ))
+        body = _post_body(mock_post)
+        assert body["viewability_tag"] == {
+            "values": [{"tag": "<script>1</script>", "type": "IAS"}],
+        }
+
+    @pytest.mark.asyncio
+    @patch('realize.tools.item_display_handlers.client.post', new_callable=AsyncMock)
+    async def test_viewability_tag_empty_clears(self, mock_post):
+        mock_post.return_value = {"id": "987654321"}
+        await handle_call_tool("update_display_item", _args(
+            viewability_tag={"values": []},
+        ))
+        body = _post_body(mock_post)
+        assert body["viewability_tag"] == {"values": []}
+
+
+class TestUpdateDisplayItemMultiField:
+    @pytest.mark.asyncio
+    @patch('realize.tools.item_display_handlers.client.post', new_callable=AsyncMock)
+    async def test_multi_field_update(self, mock_post):
+        mock_post.return_value = {"id": "987654321"}
+        await handle_call_tool("update_display_item", _args(
+            url="https://example.com/landing-v2",
+            ad_tag=_AD_TAG,
+            dimensions=[{"width": 300, "height": 250}],
+            verification_pixel={
+                "verification_pixel_items": [
+                    {"url": "https://x.example/c", "verification_pixel_type": "CLICK"},
+                ],
+            },
+        ))
+        body = _post_body(mock_post)
+        assert body["is_active"] is False
+        assert body["url"] == "https://example.com/landing-v2"
+        assert body["display_data"] == {
+            "ad_tag": _AD_TAG,
+            "dimensions": [{"width": 300, "height": 250}],
+        }
+        assert body["verification_pixel"] == {
+            "verification_pixel_items": [
+                {"url": "https://x.example/c", "verification_pixel_type": "CLICK"},
+            ],
+        }
+
+
+class TestUpdateDisplayItemAnnotations:
+    @pytest.mark.asyncio
+    async def test_has_destructive_idempotent_annotations(self):
+        from realize.realize_server import handle_list_tools
+
+        tools = await handle_list_tools()
+        update = next(t for t in tools if t.name == "update_display_item")
+
+        assert update.annotations is not None
+        assert update.annotations.destructiveHint is True
+        assert update.annotations.idempotentHint is True
+        assert update.annotations.openWorldHint is True
+
+    @pytest.mark.asyncio
+    async def test_required_fields_in_schema(self):
+        from realize.realize_server import handle_list_tools
+
+        tools = await handle_list_tools()
+        update = next(t for t in tools if t.name == "update_display_item")
+
+        assert set(update.inputSchema["required"]) == {"account_id", "campaign_id", "item_id"}
+
+    @pytest.mark.asyncio
+    async def test_asset_url_in_update_schema(self):
+        from realize.realize_server import handle_list_tools
+
+        tools = await handle_list_tools()
+        update = next(t for t in tools if t.name == "update_display_item")
+
+        assert "asset_url" in update.inputSchema["properties"]
+        assert "ad_tag" in update.inputSchema["properties"]
+
+    @pytest.mark.asyncio
+    async def test_native_only_fields_absent(self):
+        """Native-specific scalars don't apply to display items."""
+        from realize.realize_server import handle_list_tools
+
+        tools = await handle_list_tools()
+        update = next(t for t in tools if t.name == "update_display_item")
+
+        for f in ("title", "description", "thumbnail_url"):
+            assert f not in update.inputSchema["properties"], \
+                f"update_display_item must not expose {f} (native-only field)"

--- a/tests/test_update_native_item.py
+++ b/tests/test_update_native_item.py
@@ -80,14 +80,14 @@ class TestUpdateCampaignItemBaseValidation:
 
 class TestUpdateCampaignItemWireMapping:
     @pytest.mark.asyncio
-    @patch('realize.tools.item_handlers.client.post', new_callable=AsyncMock)
+    @patch('realize.tools.item_native_handlers.client.post', new_callable=AsyncMock)
     async def test_posts_to_item_endpoint(self, mock_post):
         mock_post.return_value = {"id": "987654321"}
         await handle_call_tool("update_native_item", _args())
         assert _post_endpoint(mock_post) == "/acme-inc/campaigns/49184816/items/987654321"
 
     @pytest.mark.asyncio
-    @patch('realize.tools.item_handlers.client.post', new_callable=AsyncMock)
+    @patch('realize.tools.item_native_handlers.client.post', new_callable=AsyncMock)
     async def test_url_encodes_path_segments(self, mock_post):
         mock_post.return_value = {"id": "987654321"}
         await handle_call_tool("update_native_item", _args(
@@ -98,7 +98,7 @@ class TestUpdateCampaignItemWireMapping:
         assert _post_endpoint(mock_post) == "/acme%2Fevil/campaigns/c%2F1/items/i%2F1"
 
     @pytest.mark.asyncio
-    @patch('realize.tools.item_handlers.client.post', new_callable=AsyncMock)
+    @patch('realize.tools.item_native_handlers.client.post', new_callable=AsyncMock)
     async def test_path_ids_not_in_body(self, mock_post):
         mock_post.return_value = {"id": "987654321"}
         await handle_call_tool("update_native_item", _args())
@@ -108,7 +108,7 @@ class TestUpdateCampaignItemWireMapping:
         assert "item_id" not in body
 
     @pytest.mark.asyncio
-    @patch('realize.tools.item_handlers.client.post', new_callable=AsyncMock)
+    @patch('realize.tools.item_native_handlers.client.post', new_callable=AsyncMock)
     async def test_single_scalar_passes_through(self, mock_post):
         mock_post.return_value = {"id": "987654321"}
         await handle_call_tool("update_native_item", _args())
@@ -123,17 +123,37 @@ class TestUpdateCampaignItemWireMapping:
         ("is_active", True),
     ])
     @pytest.mark.asyncio
-    @patch('realize.tools.item_handlers.client.post', new_callable=AsyncMock)
+    @patch('realize.tools.item_native_handlers.client.post', new_callable=AsyncMock)
     async def test_scalar_field_pass_through(self, mock_post, field, value):
         mock_post.return_value = {"id": "987654321"}
         args = {"account_id": "acme-inc", "campaign_id": "49184816", "item_id": "987654321", field: value}
         await handle_call_tool("update_native_item", args)
         assert _post_body(mock_post) == {field: value}
 
+    @pytest.mark.asyncio
+    @patch('realize.tools.item_native_handlers.client.post', new_callable=AsyncMock)
+    async def test_creative_name_only(self, mock_post):
+        mock_post.return_value = {"id": "987654321"}
+        await handle_call_tool(
+            "update_native_item",
+            {
+                "account_id": "acme-inc",
+                "campaign_id": "49184816",
+                "item_id": "987654321",
+                "creative_name": "Native renamed",
+            },
+        )
+        assert _post_body(mock_post) == {"custom_data": {"creative_name": "Native renamed"}}
+
+    @pytest.mark.asyncio
+    async def test_creative_name_blank_rejected(self):
+        with pytest.raises(ToolInputError, match="creative_name must be a non-empty string"):
+            await handle_call_tool("update_native_item", _args(creative_name=""))
+
 
 class TestUpdateCampaignItemNested:
     @pytest.mark.asyncio
-    @patch('realize.tools.item_handlers.client.post', new_callable=AsyncMock)
+    @patch('realize.tools.item_native_handlers.client.post', new_callable=AsyncMock)
     async def test_cta_passes_through(self, mock_post):
         mock_post.return_value = {"id": "987654321"}
         await handle_call_tool(
@@ -149,7 +169,7 @@ class TestUpdateCampaignItemNested:
             await handle_call_tool("update_native_item", _args(cta={"cta_type": ""}))
 
     @pytest.mark.asyncio
-    @patch('realize.tools.item_handlers.client.post', new_callable=AsyncMock)
+    @patch('realize.tools.item_native_handlers.client.post', new_callable=AsyncMock)
     async def test_verification_pixel_full_replace(self, mock_post):
         mock_post.return_value = {"id": "987654321"}
         await handle_call_tool("update_native_item", _args(
@@ -169,7 +189,7 @@ class TestUpdateCampaignItemNested:
         }
 
     @pytest.mark.asyncio
-    @patch('realize.tools.item_handlers.client.post', new_callable=AsyncMock)
+    @patch('realize.tools.item_native_handlers.client.post', new_callable=AsyncMock)
     async def test_verification_pixel_empty_clears(self, mock_post):
         mock_post.return_value = {"id": "987654321"}
         await handle_call_tool("update_native_item", _args(
@@ -206,7 +226,7 @@ class TestUpdateCampaignItemNested:
             await handle_call_tool("update_native_item", _args(verification_pixel=[]))
 
     @pytest.mark.asyncio
-    @patch('realize.tools.item_handlers.client.post', new_callable=AsyncMock)
+    @patch('realize.tools.item_native_handlers.client.post', new_callable=AsyncMock)
     async def test_viewability_tag_full_replace(self, mock_post):
         mock_post.return_value = {"id": "987654321"}
         await handle_call_tool("update_native_item", _args(
@@ -226,7 +246,7 @@ class TestUpdateCampaignItemNested:
         }
 
     @pytest.mark.asyncio
-    @patch('realize.tools.item_handlers.client.post', new_callable=AsyncMock)
+    @patch('realize.tools.item_native_handlers.client.post', new_callable=AsyncMock)
     async def test_viewability_tag_empty_clears(self, mock_post):
         mock_post.return_value = {"id": "987654321"}
         await handle_call_tool("update_native_item", _args(
@@ -250,7 +270,7 @@ class TestUpdateCampaignItemNested:
 
 class TestUpdateCampaignItemMultiField:
     @pytest.mark.asyncio
-    @patch('realize.tools.item_handlers.client.post', new_callable=AsyncMock)
+    @patch('realize.tools.item_native_handlers.client.post', new_callable=AsyncMock)
     async def test_multi_field_update(self, mock_post):
         mock_post.return_value = {"id": "987654321"}
         await handle_call_tool("update_native_item", _args(


### PR DESCRIPTION
- creative_name — surfaced on native item create + update via `custom_data.creative_name`.
- VCPM pricing_model — new `[CPC, VCPM]` enum on campaign tools; VCPM requires FIXED bid, cpc carries vCPM rate.
- Display item tools — split `item_handlers.py` 3-ways, added `create_display_item` + `update_display_item` supporting 3P ad_tag and 1P asset_url modes.
- ENABLE_DISPLAY_ITEM_TOOLS flag — env var (default false) gates display tools out of `get_all_tools()`.